### PR TITLE
Implement a transaction framework for easy testing.

### DIFF
--- a/pkg/blockissuer/block_params.go
+++ b/pkg/blockissuer/block_params.go
@@ -25,9 +25,32 @@ func WithParentsCount(parentsCount int) func(builder *BlockParams) {
 	}
 }
 
-func WithReferences(references model.ParentReferences) func(builder *BlockParams) {
+func WithStrongParents(blockIDs ...iotago.BlockID) func(builder *BlockParams) {
 	return func(builder *BlockParams) {
-		builder.references = references
+		if builder.references == nil {
+			builder.references = make(model.ParentReferences)
+		}
+
+		builder.references[model.StrongParentType] = blockIDs
+	}
+}
+func WithWeakParents(blockIDs ...iotago.BlockID) func(builder *BlockParams) {
+	return func(builder *BlockParams) {
+		if builder.references == nil {
+			builder.references = make(model.ParentReferences)
+		}
+
+		builder.references[model.WeakParentType] = blockIDs
+	}
+}
+
+func WithShallowLikeParents(blockIDs ...iotago.BlockID) func(builder *BlockParams) {
+	return func(builder *BlockParams) {
+		if builder.references == nil {
+			builder.references = make(model.ParentReferences)
+		}
+
+		builder.references[model.ShallowLikeParentType] = blockIDs
 	}
 }
 

--- a/pkg/protocol/engine/blocks/block.go
+++ b/pkg/protocol/engine/blocks/block.go
@@ -345,18 +345,30 @@ func (b *Block) Witnesses() []iotago.AccountID {
 }
 
 func (b *Block) ConflictIDs() *advancedset.AdvancedSet[iotago.TransactionID] {
+	b.mutex.RLock()
+	defer b.mutex.RUnlock()
+
 	return b.conflictIDs
 }
 
 func (b *Block) SetConflictIDs(conflictIDs *advancedset.AdvancedSet[iotago.TransactionID]) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
 	b.conflictIDs = conflictIDs
 }
 
 func (b *Block) PayloadConflictIDs() *advancedset.AdvancedSet[iotago.TransactionID] {
+	b.mutex.RLock()
+	defer b.mutex.RUnlock()
+
 	return b.payloadConflictIDs
 }
 
 func (b *Block) SetPayloadConflictIDs(payloadConflictIDs *advancedset.AdvancedSet[iotago.TransactionID]) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
 	b.payloadConflictIDs = payloadConflictIDs
 }
 

--- a/pkg/protocol/engine/events.go
+++ b/pkg/protocol/engine/events.go
@@ -10,6 +10,7 @@ import (
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/consensus/slotgadget"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/eviction"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/filter"
+	"github.com/iotaledger/iota-core/pkg/protocol/engine/mempool/conflictdag"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/notarization"
 	iotago "github.com/iotaledger/iota.go/v4"
 )
@@ -26,6 +27,7 @@ type Events struct {
 	BlockGadget    *blockgadget.Events
 	SlotGadget     *slotgadget.Events
 	Notarization   *notarization.Events
+	ConflictDAG    *conflictdag.Events[iotago.TransactionID, iotago.OutputID]
 
 	event.Group[Events, *Events]
 }
@@ -43,5 +45,6 @@ var NewEvents = event.CreateGroupConstructor(func() (newEvents *Events) {
 		BlockGadget:    blockgadget.NewEvents(),
 		SlotGadget:     slotgadget.NewEvents(),
 		Notarization:   notarization.NewEvents(),
+		ConflictDAG:    conflictdag.NewEvents[iotago.TransactionID, iotago.OutputID](),
 	}
 })

--- a/pkg/protocol/engine/ledger/ledger.go
+++ b/pkg/protocol/engine/ledger/ledger.go
@@ -3,6 +3,7 @@ package ledger
 import (
 	"io"
 
+	"github.com/iotaledger/hive.go/runtime/event"
 	"github.com/iotaledger/hive.go/runtime/module"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/blocks"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/booker"
@@ -14,7 +15,10 @@ import (
 
 type Ledger interface {
 	AttachTransaction(block *blocks.Block) (transactionMetadata mempool.TransactionMetadata, containsTransaction bool)
+	OnTransactionAttached(callback func(transactionMetadata mempool.TransactionMetadata), opts ...event.Option)
 	Output(id iotago.IndexedUTXOReferencer) (*ledgerstate.Output, error)
+	TransactionMetadata(id iotago.TransactionID) (transactionMetadata mempool.TransactionMetadata, exists bool)
+	TransactionMetadataByAttachment(blockID iotago.BlockID) (transactionMetadata mempool.TransactionMetadata, exists bool)
 	CommitSlot(index iotago.SlotIndex) (stateRoot iotago.Identifier, mutationRoot iotago.Identifier, err error)
 	ConflictDAG() conflictdag.ConflictDAG[iotago.TransactionID, iotago.OutputID, booker.BlockVotePower]
 	IsOutputSpent(outputID iotago.OutputID) (bool, error)

--- a/pkg/protocol/engine/ledger/utxoledger/ledger.go
+++ b/pkg/protocol/engine/ledger/utxoledger/ledger.go
@@ -40,6 +40,8 @@ func NewProvider() module.Provider[*engine.Engine, ledger.Ledger] {
 	return module.Provide(func(e *engine.Engine) ledger.Ledger {
 		l := New(e.Workers.CreateGroup("Ledger"), e.Storage.Ledger(), executeStardustVM, e.API, e.SybilProtection.OnlineCommittee(), e.ErrorHandler("ledger"))
 
+		e.Events.ConflictDAG.LinkTo(l.conflictDAG.Events())
+
 		// TODO: should this attach to RatifiedAccepted instead?
 		e.Events.BlockGadget.BlockAccepted.Hook(l.BlockAccepted)
 

--- a/pkg/protocol/engine/ledger/utxoledger/ledger.go
+++ b/pkg/protocol/engine/ledger/utxoledger/ledger.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/iotaledger/hive.go/core/account"
 	"github.com/iotaledger/hive.go/kvstore"
+	"github.com/iotaledger/hive.go/runtime/event"
 	"github.com/iotaledger/hive.go/runtime/module"
 	"github.com/iotaledger/hive.go/runtime/workerpool"
 	"github.com/iotaledger/iota-core/pkg/core/promise"
@@ -215,6 +216,17 @@ func (l *Ledger) AttachTransaction(block *blocks.Block) (transactionMetadata mem
 
 		return nil, false
 	}
+}
+
+func (l *Ledger) OnTransactionAttached(handler func(transaction mempool.TransactionMetadata), opts ...event.Option) {
+	l.memPool.OnTransactionAttached(handler, opts...)
+}
+
+func (l *Ledger) TransactionMetadata(transactionID iotago.TransactionID) (mempool.TransactionMetadata, bool) {
+	return l.memPool.TransactionMetadata(transactionID)
+}
+func (l *Ledger) TransactionMetadataByAttachment(blockID iotago.BlockID) (mempool.TransactionMetadata, bool) {
+	return l.memPool.TransactionMetadataByAttachment(blockID)
 }
 
 func (l *Ledger) BlockAccepted(block *blocks.Block) {

--- a/pkg/protocol/engine/mempool/conflictdag/conflictdagv1/conflict.go
+++ b/pkg/protocol/engine/mempool/conflictdag/conflictdagv1/conflict.go
@@ -109,7 +109,7 @@ func NewConflict[ConflictID, ResourceID conflictdag.IDType, VotePower conflictda
 	c.preferredInstead = c
 
 	c.unhookAcceptanceMonitoring = c.Weight.OnUpdate.Hook(func(value weight.Value) {
-		if threshold := c.acceptanceThreshold(); value.AcceptanceState().IsPending() && value.ValidatorsWeight() >= threshold {
+		if value.AcceptanceState().IsPending() && value.ValidatorsWeight() >= c.acceptanceThreshold() {
 			c.setAcceptanceState(acceptance.Accepted)
 		}
 	}).Unhook

--- a/pkg/protocol/engine/mempool/v1/mempool.go
+++ b/pkg/protocol/engine/mempool/v1/mempool.go
@@ -335,7 +335,6 @@ func (m *MemPool[VotePower]) updateStateDiffs(transaction *TransactionMetadata, 
 
 func (m *MemPool[VotePower]) setup() {
 	m.conflictDAG.Events().ConflictAccepted.Hook(func(id iotago.TransactionID) {
-
 		if transaction, exists := m.cachedTransactions.Get(id); exists {
 			transaction.setConflictAccepted()
 		}

--- a/pkg/protocol/engine/mempool/v1/mempool.go
+++ b/pkg/protocol/engine/mempool/v1/mempool.go
@@ -335,7 +335,8 @@ func (m *MemPool[VotePower]) updateStateDiffs(transaction *TransactionMetadata, 
 
 func (m *MemPool[VotePower]) setup() {
 	m.conflictDAG.Events().ConflictAccepted.Hook(func(id iotago.TransactionID) {
-		if transaction, exists := m.cachedTransactions.Get(id); !exists {
+
+		if transaction, exists := m.cachedTransactions.Get(id); exists {
 			transaction.setConflictAccepted()
 		}
 	})

--- a/pkg/tests/booker_test.go
+++ b/pkg/tests/booker_test.go
@@ -4,28 +4,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/iotaledger/hive.go/runtime/options"
 	"github.com/iotaledger/iota-core/pkg/blockissuer"
+	"github.com/iotaledger/iota-core/pkg/model"
 	"github.com/iotaledger/iota-core/pkg/protocol"
-	"github.com/iotaledger/iota-core/pkg/protocol/engine/blocks"
-	"github.com/iotaledger/iota-core/pkg/protocol/engine/notarization/slotnotarization"
 	"github.com/iotaledger/iota-core/pkg/testsuite"
 )
 
-func TestBooker(t *testing.T) {
+func Test_IssuingTransactionsOutOfOrder(t *testing.T) {
 	ts := testsuite.NewTestSuite(t)
 	defer ts.Shutdown()
 
 	node1 := ts.AddValidatorNode("node1", 1)
-	ts.Run(map[string][]options.Option[protocol.Protocol]{
-		"node1": {
-			protocol.WithNotarizationProvider(
-				slotnotarization.NewProvider(slotnotarization.WithMinCommittableSlotAge(1)),
-			),
-		},
-	})
+	ts.Run(map[string][]options.Option[protocol.Protocol]{})
 
 	node1.HookLogging()
 
@@ -35,11 +26,6 @@ func TestBooker(t *testing.T) {
 
 	tx2 := ts.CreateTransaction("Tx2", 1, "Tx1:0")
 
-	blocksBooked := 0
-	node1.Protocol.MainEngineInstance().Events.Booker.BlockBooked.Hook(func(_ *blocks.Block) {
-		blocksBooked++
-	})
-
 	ts.RegisterBlock("block1", node1.IssueBlock("block1", blockissuer.WithPayload(tx2)))
 	ts.Wait(node1)
 
@@ -47,14 +33,12 @@ func TestBooker(t *testing.T) {
 	ts.AssertTransactionsExist([]string{"Tx1"}, false, node1)
 
 	ts.AssertTransactionsInCacheBooked([]string{"Tx2"}, false, node1)
-	require.Equal(t, 0, blocksBooked)
 
 	ts.RegisterBlock("block2", node1.IssueBlock("block2", blockissuer.WithPayload(tx1)))
 	ts.Wait(node1)
 
 	ts.AssertTransactionsExist([]string{"Tx1", "Tx2"}, true, node1)
 	ts.AssertTransactionsInCacheBooked([]string{"Tx1", "Tx2"}, true, node1)
-	require.Equal(t, 2, blocksBooked)
 	ts.AssertBlocksInCacheConflicts(map[string][]string{
 		"block1": {"Tx2"},
 		"block2": {"Tx1"},
@@ -64,4 +48,86 @@ func TestBooker(t *testing.T) {
 		"Tx2": {"Tx2"},
 		"Tx1": {"Tx1"},
 	}, node1)
+}
+
+func Test_DoubleSpend(t *testing.T) {
+	ts := testsuite.NewTestSuite(t)
+	defer ts.Shutdown()
+
+	node1 := ts.AddValidatorNode("node1", 1)
+	node2 := ts.AddValidatorNode("node2", 1)
+
+	ts.Run(map[string][]options.Option[protocol.Protocol]{})
+
+	node1.HookLogging()
+
+	time.Sleep(time.Second)
+	//Create and issue double spends
+	{
+		tx1 := ts.CreateTransaction("Tx1", 1, "Genesis")
+		tx2 := ts.CreateTransaction("Tx2", 1, "Genesis")
+
+		ts.RegisterBlock("block1", node1.IssueBlock("block1", blockissuer.WithPayload(tx1)))
+		ts.RegisterBlock("block2", node1.IssueBlock("block2", blockissuer.WithPayload(tx2)))
+		ts.Wait(node1, node2)
+
+		ts.AssertTransactionsExist([]string{"Tx1", "Tx2"}, true, node1, node2)
+		ts.AssertTransactionsInCacheBooked([]string{"Tx1", "Tx2"}, true, node1, node2)
+		ts.AssertTransactionsInCachePending([]string{"Tx1", "Tx2"}, true, node1, node2)
+		ts.AssertBlocksInCacheConflicts(map[string][]string{
+			"block1": {"Tx1"},
+			"block2": {"Tx2"},
+		}, node1, node2)
+
+		ts.AssertTransactionInCacheConflicts(map[string][]string{
+			"Tx2": {"Tx2"},
+			"Tx1": {"Tx1"},
+		}, node1, node2)
+	}
+
+	// Issue some more blocks and assert that conflicts are propagated to blocks.
+	{
+		references := make(model.ParentReferences)
+		references[model.StrongParentType] = ts.BlockIDs("block1")
+		ts.RegisterBlock("block3", node1.IssueBlock("block3", blockissuer.WithReferences(references)))
+
+		references = make(model.ParentReferences)
+		references[model.StrongParentType] = ts.BlockIDs("block2")
+		ts.RegisterBlock("block4", node1.IssueBlock("block4", blockissuer.WithReferences(references)))
+		ts.Wait(node1, node2)
+
+		ts.AssertBlocksInCacheConflicts(map[string][]string{
+			"block3": {"Tx1"},
+			"block4": {"Tx2"},
+		}, node1, node2)
+		ts.AssertTransactionsInCachePending([]string{"Tx1", "Tx2"}, true, node1, node2)
+	}
+
+	// Issue an invalid block and assert that its vote is not cast.
+	{
+		references := make(model.ParentReferences)
+		references[model.StrongParentType] = ts.BlockIDs("block3", "block4")
+		ts.RegisterBlock("block5", node2.IssueBlock("block5", blockissuer.WithReferences(references)))
+		ts.Wait(node1, node2)
+
+		ts.AssertTransactionsInCachePending([]string{"Tx1", "Tx2"}, true, node1, node2)
+	}
+
+	// Issue a valid block that resolves the conflict.
+	{
+		references := make(model.ParentReferences)
+		references[model.StrongParentType] = ts.BlockIDs("block3", "block4")
+		references[model.ShallowLikeParentType] = ts.BlockIDs("block2")
+
+		ts.RegisterBlock("block6", node2.IssueBlock("block6", blockissuer.WithReferences(references)))
+		ts.Wait(node1, node2)
+
+		ts.AssertBlocksInCacheConflicts(map[string][]string{
+			"block6": {"Tx2"},
+		}, node1, node2)
+		ts.AssertTransactionsInCachePending([]string{"Tx1", "Tx2"}, false, node1, node2)
+		ts.AssertTransactionsInCacheAccepted([]string{"Tx2"}, true, node1, node2)
+		ts.AssertTransactionsInCacheRejected([]string{"Tx1"}, true, node1, node2)
+
+	}
 }

--- a/pkg/tests/booker_test.go
+++ b/pkg/tests/booker_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/iotaledger/hive.go/runtime/options"
 	"github.com/iotaledger/iota-core/pkg/blockissuer"
+	"github.com/iotaledger/iota-core/pkg/core/acceptance"
 	"github.com/iotaledger/iota-core/pkg/model"
 	"github.com/iotaledger/iota-core/pkg/protocol"
 	"github.com/iotaledger/iota-core/pkg/testsuite"
@@ -125,9 +126,98 @@ func Test_DoubleSpend(t *testing.T) {
 		ts.AssertBlocksInCacheConflicts(map[string][]string{
 			"block6": {"Tx2"},
 		}, node1, node2)
-		ts.AssertTransactionsInCachePending([]string{"Tx1", "Tx2"}, false, node1, node2)
 		ts.AssertTransactionsInCacheAccepted([]string{"Tx2"}, true, node1, node2)
 		ts.AssertTransactionsInCacheRejected([]string{"Tx1"}, true, node1, node2)
 
+	}
+}
+
+func Test_MultipleAttachments(t *testing.T) {
+	ts := testsuite.NewTestSuite(t)
+	defer ts.Shutdown()
+
+	node1 := ts.AddValidatorNode("node1", 1)
+	node2 := ts.AddValidatorNode("node2", 1)
+
+	ts.Run(map[string][]options.Option[protocol.Protocol]{})
+
+	node1.HookLogging()
+
+	time.Sleep(time.Second)
+	//Create a transaction and issue it from both nodes, so that the conflict is accepted, but none attachment is not included yet.
+	{
+		tx1 := ts.CreateTransaction("Tx1", 2, "Genesis")
+
+		references := make(model.ParentReferences)
+		references[model.StrongParentType] = ts.BlockIDs("Genesis")
+		ts.RegisterBlock("block1", node1.IssueBlock("block1", blockissuer.WithPayload(tx1), blockissuer.WithReferences(references)))
+		ts.RegisterBlock("block2", node2.IssueBlock("block2", blockissuer.WithPayload(tx1), blockissuer.WithReferences(references)))
+		ts.Wait(node1, node2)
+
+		ts.AssertTransactionsExist([]string{"Tx1"}, true, node1, node2)
+		ts.AssertTransactionsInCacheBooked([]string{"Tx1"}, true, node1, node2)
+		ts.AssertTransactionsInCachePending([]string{"Tx1"}, true, node1, node2)
+		ts.AssertBlocksInCacheConflicts(map[string][]string{
+			"block1": {"Tx1"},
+			"block2": {"Tx1"},
+		}, node1, node2)
+		ts.AssertTransactionInCacheConflicts(map[string][]string{
+			"Tx1": {"Tx1"},
+		}, node1, node2)
+		ts.AssertConflictsInCacheAcceptanceState([]string{"Tx1"}, acceptance.Accepted, node1, node2)
+	}
+
+	//Create a transaction that is included and whose conflict is accepted, but whose inputs are not accepted.
+	{
+		tx2 := ts.CreateTransaction("Tx2", 1, "Tx1:1")
+
+		references := make(model.ParentReferences)
+		references[model.StrongParentType] = ts.BlockIDs("Genesis")
+		ts.RegisterBlock("block3", node1.IssueBlock("block3", blockissuer.WithPayload(tx2), blockissuer.WithReferences(references)))
+
+		references = make(model.ParentReferences)
+		references[model.StrongParentType] = ts.BlockIDs("block3")
+		ts.RegisterBlock("block4", node2.IssueBlock("block4", blockissuer.WithReferences(references)))
+		ts.Wait(node1, node2)
+
+		ts.AssertTransactionsExist([]string{"Tx1", "Tx2"}, true, node1, node2)
+		ts.AssertTransactionsInCacheBooked([]string{"Tx1", "Tx2"}, true, node1, node2)
+		ts.AssertTransactionsInCachePending([]string{"Tx1", "Tx2"}, true, node1, node2)
+		ts.AssertBlocksInCacheConflicts(map[string][]string{
+			"block1": {"Tx1"},
+			"block2": {"Tx1"},
+			"block3": {"Tx2"},
+			"block4": {"Tx2"},
+		}, node1, node2)
+		ts.AssertTransactionInCacheConflicts(map[string][]string{
+			"Tx1": {"Tx1"},
+			"Tx2": {"Tx2"},
+		}, node1, node2)
+		ts.AssertConflictsInCacheAcceptanceState([]string{"Tx1", "Tx2"}, acceptance.Accepted, node1, node2)
+	}
+
+	//Issue a block that includes Tx1, and make sure that Tx2 is accepted as well as a consequence.
+	{
+		references := make(model.ParentReferences)
+		references[model.StrongParentType] = ts.BlockIDs("block1")
+		ts.RegisterBlock("block5", node2.IssueBlock("block5", blockissuer.WithReferences(references)))
+
+		ts.Wait(node1, node2)
+
+		ts.AssertTransactionsExist([]string{"Tx1", "Tx2"}, true, node1, node2)
+		ts.AssertTransactionsInCacheBooked([]string{"Tx1", "Tx2"}, true, node1, node2)
+		ts.AssertTransactionsInCacheAccepted([]string{"Tx1", "Tx2"}, true, node1, node2)
+		ts.AssertBlocksInCacheConflicts(map[string][]string{
+			"block1": {"Tx1"},
+			"block2": {"Tx1"},
+			"block3": {"Tx2"},
+			"block4": {"Tx2"},
+			"block5": {},
+		}, node1, node2)
+		ts.AssertTransactionInCacheConflicts(map[string][]string{
+			"Tx1": {"Tx1"},
+			"Tx2": {"Tx2"},
+		}, node1, node2)
+		ts.AssertConflictsInCacheAcceptanceState([]string{"Tx1", "Tx2"}, acceptance.Accepted, node1, node2)
 	}
 }

--- a/pkg/tests/booker_test.go
+++ b/pkg/tests/booker_test.go
@@ -6,16 +6,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/iotaledger/hive.go/lo"
 	"github.com/iotaledger/hive.go/runtime/options"
 	"github.com/iotaledger/iota-core/pkg/blockissuer"
 	"github.com/iotaledger/iota-core/pkg/protocol"
+	"github.com/iotaledger/iota-core/pkg/protocol/engine/blocks"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/notarization/slotnotarization"
 	"github.com/iotaledger/iota-core/pkg/protocol/snapshotcreator"
 	"github.com/iotaledger/iota-core/pkg/testsuite"
-	"github.com/iotaledger/iota-core/pkg/testsuite/mock"
-	iotago "github.com/iotaledger/iota.go/v4"
-	"github.com/iotaledger/iota.go/v4/builder"
 	"github.com/iotaledger/iota.go/v4/tpkg"
 )
 
@@ -25,9 +22,6 @@ func TestBooker(t *testing.T) {
 		snapshotcreator.WithGenesisSeed(genesisSeed[:]),
 	))
 	defer ts.Shutdown()
-
-	walletFrom := mock.NewHDWallet("genesis", genesisSeed[:], 0)
-	walletTo := mock.NewHDWallet("genesis", genesisSeed[:], 2)
 
 	node1 := ts.AddValidatorNode("node1", 1)
 	ts.Run(map[string][]options.Option[protocol.Protocol]{
@@ -39,30 +33,24 @@ func TestBooker(t *testing.T) {
 	})
 	time.Sleep(time.Second)
 
-	output, err := node1.Protocol.MainEngineInstance().Ledger.Output(&iotago.UTXOInput{TransactionID: iotago.TransactionID{}, TransactionOutputIndex: 0})
+	transactionFramework := testsuite.NewTransactionFramework(node1.Protocol, genesisSeed[:])
+	tx1, err := transactionFramework.CreateTransaction("Tx1", 1, "Genesis")
 	require.NoError(t, err)
 
-	transaction, err := builder.NewTransactionBuilder(ts.Node("node1").Protocol.MainEngineInstance().Storage.Settings().ProtocolParameters().NetworkID()).
-		AddInput(&builder.TxInput{UnlockTarget: output.Output().UnlockConditionSet().Address().Address, InputID: output.OutputID(), Input: output.Output()}).
-		AddOutput(&iotago.BasicOutput{
-			Amount: 10000000,
-			Conditions: iotago.BasicOutputUnlockConditions{
-				&iotago.AddressUnlockCondition{Address: walletTo.Address()},
-			},
-		}).
-		Build(node1.Protocol.MainEngineInstance().Storage.Settings().ProtocolParameters(), iotago.NewInMemoryAddressSigner(iotago.NewAddressKeysForEd25519Address(walletFrom.Address(), lo.Return1(walletFrom.KeyPair()))))
-	require.NoError(t, err)
+	tx2, err := transactionFramework.CreateTransaction("Tx2", 1, "Tx1:0")
 
-	node1.IssueBlock("block1", blockissuer.WithPayload(transaction))
+	blocksBooked := 0
+	node1.Protocol.MainEngineInstance().Events.Booker.BlockBooked.Hook(func(_ *blocks.Block) {
+		blocksBooked++
+	})
 
+	node1.IssueBlock("block1", blockissuer.WithPayload(tx2))
 	ts.Wait(node1)
 
-	newOutput, err := node1.Protocol.MainEngineInstance().Ledger.Output(&iotago.UTXOInput{TransactionID: lo.PanicOnErr(transaction.ID()), TransactionOutputIndex: 0})
-	require.NoError(t, err)
+	require.Equal(t, 0, blocksBooked)
 
-	genesisOutput, err := node1.Protocol.MainEngineInstance().Ledger.Output(&iotago.UTXOInput{TransactionID: iotago.TransactionID{}, TransactionOutputIndex: 0})
-	require.NoError(t, err)
+	node1.IssueBlock("block2", blockissuer.WithPayload(tx1))
+	ts.Wait(node1)
 
-	require.EqualValues(t, 0, genesisOutput.SlotIndexBooked())
-	require.EqualValues(t, 101, newOutput.SlotIndexBooked())
+	require.Equal(t, 2, blocksBooked)
 }

--- a/pkg/testsuite/blocks.go
+++ b/pkg/testsuite/blocks.go
@@ -96,13 +96,13 @@ func (t *TestSuite) AssertBlocksInCacheRootBlock(expectedBlocks []*blocks.Block,
 	t.assertBlocksInCacheWithFunc(expectedBlocks, expectedRootBlock, (*blocks.Block).IsRootBlock, nodes...)
 }
 
-func (t *TestSuite) AssertBlocksInCacheConflicts(blockConflicts map[string][]string, nodes ...*mock.Node) {
+func (t *TestSuite) AssertBlocksInCacheConflicts(blockConflicts map[*blocks.Block][]string, nodes ...*mock.Node) {
 	for _, node := range nodes {
-		for blockAlias, conflictAliases := range blockConflicts {
+		for block, conflictAliases := range blockConflicts {
 			t.Eventually(func() error {
-				blockFromCache, exists := node.Protocol.MainEngineInstance().BlockFromCache(t.BlockID(blockAlias))
+				blockFromCache, exists := node.Protocol.MainEngineInstance().BlockFromCache(block.ID())
 				if !exists {
-					return errors.Errorf("AssertBlocksInCacheConflicts: %s: block %s does not exist", node.Name, blockAlias)
+					return errors.Errorf("AssertBlocksInCacheConflicts: %s: block %s does not exist", node.Name, block.ID())
 				}
 
 				if blockFromCache.IsRootBlock() {

--- a/pkg/testsuite/conflicts.go
+++ b/pkg/testsuite/conflicts.go
@@ -1,0 +1,27 @@
+package testsuite
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/iotaledger/hive.go/ds/advancedset"
+	"github.com/iotaledger/iota-core/pkg/core/acceptance"
+	"github.com/iotaledger/iota-core/pkg/testsuite/mock"
+)
+
+func (t *TestSuite) AssertConflictsInCacheAcceptanceState(expectedConflictAliases []string, expectedState acceptance.State, nodes ...*mock.Node) {
+	mustNodes(nodes)
+
+	for _, node := range nodes {
+		for _, conflictAlias := range expectedConflictAliases {
+			t.Eventually(func() error {
+				acceptanceState := node.Protocol.MainEngineInstance().Ledger.ConflictDAG().AcceptanceState(advancedset.New(t.TransactionFramework.TransactionID(conflictAlias)))
+
+				if acceptanceState != expectedState {
+					return errors.Errorf("assertTransactionsInCacheWithFunc: %s: conflict %s is %s, but expected %s", node.Name, conflictAlias, expectedState, acceptanceState)
+				}
+
+				return nil
+			})
+		}
+	}
+}

--- a/pkg/testsuite/mock/node.go
+++ b/pkg/testsuite/mock/node.go
@@ -288,10 +288,7 @@ func (n *Node) IssueBlockAtSlot(alias string, slot iotago.SlotIndex, slotCommitm
 	issuingTime := slotTimeProvider.StartTime(slot)
 	require.Truef(n.Testing, issuingTime.Before(time.Now()), "node: %s: issued block (%s, slot: %d) is in the current (%s, slot: %d) or future slot", n.Name, issuingTime, slot, time.Now(), slotTimeProvider.IndexFromTime(time.Now()))
 
-	parentReferences := make(model.ParentReferences)
-	parentReferences[model.StrongParentType] = parents
-
-	return n.IssueBlock(alias, blockissuer.WithIssuingTime(issuingTime), blockissuer.WithSlotCommitment(slotCommitment), blockissuer.WithReferences(parentReferences))
+	return n.IssueBlock(alias, blockissuer.WithIssuingTime(issuingTime), blockissuer.WithSlotCommitment(slotCommitment), blockissuer.WithStrongParents(parents...))
 }
 
 func (n *Node) IssueActivity(ctx context.Context, duration time.Duration, wg *sync.WaitGroup) {

--- a/pkg/testsuite/mock/node.go
+++ b/pkg/testsuite/mock/node.go
@@ -194,6 +194,21 @@ func (n *Node) attachEngineLogs(instance *engine.Engine) {
 		fmt.Printf("%s > [%s] Consensus.SlotGadget.SlotConfirmed: %s\n", n.Name, engineName, slotIndex)
 	})
 
+	instance.Events.ConflictDAG.ConflictCreated.Hook(func(conflictID iotago.TransactionID) {
+		fmt.Printf("%s > [%s] ConflictDAG.ConflictCreated: %s\n", n.Name, engineName, conflictID)
+	})
+
+	instance.Events.ConflictDAG.ConflictEvicted.Hook(func(conflictID iotago.TransactionID) {
+		fmt.Printf("%s > [%s] ConflictDAG.ConflictEvicted: %s\n", n.Name, engineName, conflictID)
+	})
+	instance.Events.ConflictDAG.ConflictRejected.Hook(func(conflictID iotago.TransactionID) {
+		fmt.Printf("%s > [%s] ConflictDAG.ConflictRejected: %s\n", n.Name, engineName, conflictID)
+	})
+
+	instance.Events.ConflictDAG.ConflictAccepted.Hook(func(conflictID iotago.TransactionID) {
+		fmt.Printf("%s > [%s] ConflictDAG.ConflictAccepted: %s\n", n.Name, engineName, conflictID)
+	})
+
 	instance.Ledger.OnTransactionAttached(func(transactionMetadata mempool.TransactionMetadata) {
 		fmt.Printf("%s > [%s] Ledger.TransactionAttached: %s\n", n.Name, engineName, transactionMetadata.ID())
 

--- a/pkg/testsuite/testsuite.go
+++ b/pkg/testsuite/testsuite.go
@@ -14,11 +14,13 @@ import (
 	"github.com/iotaledger/hive.go/runtime/options"
 	"github.com/iotaledger/iota-core/pkg/protocol"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/blocks"
+	"github.com/iotaledger/iota-core/pkg/protocol/engine/ledgerstate"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/sybilprotection/poa"
 	"github.com/iotaledger/iota-core/pkg/protocol/snapshotcreator"
 	"github.com/iotaledger/iota-core/pkg/storage/utils"
 	"github.com/iotaledger/iota-core/pkg/testsuite/mock"
 	iotago "github.com/iotaledger/iota.go/v4"
+	"github.com/iotaledger/iota.go/v4/tpkg"
 )
 
 type TestSuite struct {
@@ -41,7 +43,8 @@ type TestSuite struct {
 	optsWaitFor         time.Duration
 	optsTick            time.Duration
 
-	mutex sync.RWMutex
+	mutex                sync.RWMutex
+	TransactionFramework *TransactionFramework
 }
 
 func NewTestSuite(testingT *testing.T, opts ...options.Option[TestSuite]) *TestSuite {
@@ -152,6 +155,22 @@ func (t *TestSuite) RegisterBlock(alias string, block *blocks.Block) {
 	block.ID().RegisterAlias(alias)
 }
 
+func (t *TestSuite) CreateTransactionWithInputsAndOutputs(consumedInputs ledgerstate.Outputs, outputs iotago.Outputs[iotago.Output], signingWallets []*mock.HDWallet) *iotago.Transaction {
+	if t.TransactionFramework == nil {
+		panic("cannot create a transaction without running the network first")
+	}
+
+	return lo.PanicOnErr(t.TransactionFramework.CreateTransactionWithInputsAndOutputs(consumedInputs, outputs, signingWallets))
+}
+
+func (t *TestSuite) CreateTransaction(alias string, outputCount int, inputAliases ...string) *iotago.Transaction {
+	if t.TransactionFramework == nil {
+		panic("cannot create a transaction without running the network first")
+	}
+
+	return lo.PanicOnErr(t.TransactionFramework.CreateTransaction(alias, outputCount, inputAliases...))
+}
+
 func (t *TestSuite) Node(name string) *mock.Node {
 	t.mutex.RLock()
 	defer t.mutex.RUnlock()
@@ -238,8 +257,9 @@ func (t *TestSuite) RemoveNode(name string) {
 func (t *TestSuite) Run(nodesOptions ...map[string][]options.Option[protocol.Protocol]) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
+	genesisSeed := tpkg.RandEd25519Seed()
 
-	err := snapshotcreator.CreateSnapshot(t.optsSnapshotOptions...)
+	err := snapshotcreator.CreateSnapshot(append([]options.Option[snapshotcreator.Options]{snapshotcreator.WithGenesisSeed(genesisSeed[:])}, t.optsSnapshotOptions...)...)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create snapshot: %s", err))
 	}
@@ -259,6 +279,10 @@ func (t *TestSuite) Run(nodesOptions ...map[string][]options.Option[protocol.Pro
 		}
 
 		node.Initialize(baseOpts...)
+
+		if t.TransactionFramework == nil {
+			t.TransactionFramework = NewTransactionFramework(node.Protocol, genesisSeed[:])
+		}
 	}
 
 	t.running = true

--- a/pkg/testsuite/testsuite.go
+++ b/pkg/testsuite/testsuite.go
@@ -12,6 +12,7 @@ import (
 	"github.com/iotaledger/hive.go/ds/shrinkingmap"
 	"github.com/iotaledger/hive.go/lo"
 	"github.com/iotaledger/hive.go/runtime/options"
+	"github.com/iotaledger/iota-core/pkg/blockissuer"
 	"github.com/iotaledger/iota-core/pkg/protocol"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/blocks"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/ledgerstate"
@@ -143,6 +144,19 @@ func (t *TestSuite) IssueBlockAtSlot(alias string, slot iotago.SlotIndex, slotCo
 	block := node.IssueBlockAtSlot(alias, slot, slotCommitment, parents...)
 
 	t.blocks.Set(alias, block)
+	block.ID().RegisterAlias(alias)
+
+	return block
+}
+
+func (t *TestSuite) IssueBlock(alias string, node *mock.Node, blockOpts ...options.Option[blockissuer.BlockParams]) *blocks.Block {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	block := node.IssueBlock(alias, blockOpts...)
+
+	t.blocks.Set(alias, block)
+	block.ID().RegisterAlias(alias)
 
 	return block
 }

--- a/pkg/testsuite/transactions.go
+++ b/pkg/testsuite/transactions.go
@@ -1,0 +1,112 @@
+package testsuite
+
+import (
+	"fmt"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/iotaledger/hive.go/lo"
+	"github.com/iotaledger/iota-core/pkg/protocol"
+	"github.com/iotaledger/iota-core/pkg/protocol/engine/ledgerstate"
+	"github.com/iotaledger/iota-core/pkg/testsuite/mock"
+	iotago "github.com/iotaledger/iota.go/v4"
+	"github.com/iotaledger/iota.go/v4/builder"
+)
+
+type TransactionFramework struct {
+	api         iotago.API
+	protoParams *iotago.ProtocolParameters
+
+	wallet *mock.HDWallet
+	states map[string]*ledgerstate.Output
+}
+
+func NewTransactionFramework(protocol *protocol.Protocol, genesisSeed []byte) *TransactionFramework {
+	genesisOutput, err := protocol.MainEngineInstance().Ledger.Output(iotago.OutputID{}.UTXOInput())
+	if err != nil {
+		panic(err)
+	}
+
+	return &TransactionFramework{
+		api:         protocol.API(),
+		protoParams: protocol.MainEngineInstance().Storage.Settings().ProtocolParameters(),
+		states:      map[string]*ledgerstate.Output{"Genesis": genesisOutput},
+		wallet:      mock.NewHDWallet("genesis", genesisSeed, 0),
+	}
+}
+
+func (t *TransactionFramework) CreateTransaction(alias string, outputCount int, inputAliases ...string) (*iotago.Transaction, error) {
+	inputStates := make([]*ledgerstate.Output, 0, len(inputAliases))
+	totalInputDeposits := uint64(0)
+	for _, inputAlias := range inputAliases {
+		output := t.resolveOutputAlias(inputAlias)
+		inputStates = append(inputStates, output)
+		totalInputDeposits += output.Deposit()
+	}
+
+	tokenAmount := totalInputDeposits / uint64(outputCount)
+	remainderFunds := totalInputDeposits
+
+	outputStates := make(iotago.Outputs[iotago.Output], 0, outputCount)
+	for i := 0; i < outputCount; i++ {
+		if i+1 == outputCount {
+			tokenAmount = remainderFunds
+		}
+		remainderFunds -= tokenAmount
+
+		outputStates = append(outputStates, &iotago.BasicOutput{
+			Amount: tokenAmount,
+			Conditions: iotago.BasicOutputUnlockConditions{
+				&iotago.AddressUnlockCondition{Address: t.wallet.Address()},
+			},
+		})
+	}
+
+	transaction, err := t.CreateTransactionWithInputsAndOutputs(inputStates, outputStates, []*mock.HDWallet{t.wallet})
+	if err != nil {
+		panic(err)
+	}
+	for idx, output := range outputStates {
+		t.states[fmt.Sprintf("%s:%d", alias, idx)] = ledgerstate.CreateOutput(t.api, iotago.OutputIDFromTransactionIDAndIndex(lo.PanicOnErr(transaction.ID()), uint16(idx)), iotago.EmptyBlockID(), 0, time.Now(), output)
+	}
+
+	return transaction, err
+}
+
+func (t *TransactionFramework) CreateTransactionWithInputsAndOutputs(consumedInputs ledgerstate.Outputs, outputs iotago.Outputs[iotago.Output], signingWallets []*mock.HDWallet) (*iotago.Transaction, error) {
+	walletKeys := make([]iotago.AddressKeys, len(signingWallets))
+	for i, wallet := range signingWallets {
+		inputPrivateKey, _ := wallet.KeyPair()
+		walletKeys[i] = iotago.AddressKeys{Address: wallet.Address(), Keys: inputPrivateKey}
+	}
+
+	txBuilder := builder.NewTransactionBuilder(t.protoParams.NetworkID())
+	for _, input := range consumedInputs {
+		switch input.OutputType() {
+		case iotago.OutputFoundry:
+			// For foundries we need to unlock the alias
+			txBuilder.AddInput(&builder.TxInput{UnlockTarget: input.Output().UnlockConditionSet().ImmutableAlias().Address, InputID: input.OutputID(), Input: input.Output()})
+		case iotago.OutputAlias:
+			// For alias we need to unlock the state controller
+			txBuilder.AddInput(&builder.TxInput{UnlockTarget: input.Output().UnlockConditionSet().StateControllerAddress().Address, InputID: input.OutputID(), Input: input.Output()})
+		default:
+			txBuilder.AddInput(&builder.TxInput{UnlockTarget: input.Output().UnlockConditionSet().Address().Address, InputID: input.OutputID(), Input: input.Output()})
+		}
+	}
+
+	for _, output := range outputs {
+		txBuilder.AddOutput(output)
+	}
+
+	return txBuilder.Build(t.protoParams, iotago.NewInMemoryAddressSigner(walletKeys...))
+}
+
+func (t *TransactionFramework) resolveOutputAlias(alias string) *ledgerstate.Output {
+	output, exists := t.states[alias]
+	if !exists {
+		panic(xerrors.Errorf("given alias does not exist %s", alias))
+	}
+
+	return output
+}

--- a/pkg/testsuite/transactions_framework.go
+++ b/pkg/testsuite/transactions_framework.go
@@ -132,6 +132,15 @@ func (t *TransactionFramework) Transaction(alias string) *iotago.Transaction {
 
 	return transaction
 }
+
 func (t *TransactionFramework) TransactionID(alias string) iotago.TransactionID {
 	return lo.PanicOnErr(t.Transaction(alias).ID())
+}
+
+func (t *TransactionFramework) Transactions(aliases ...string) []*iotago.Transaction {
+	return lo.Map(aliases, t.Transaction)
+}
+
+func (t *TransactionFramework) TransactionIDs(aliases ...string) []iotago.TransactionID {
+	return lo.Map(aliases, t.TransactionID)
 }

--- a/pkg/testsuite/transactions_framework.go
+++ b/pkg/testsuite/transactions_framework.go
@@ -1,0 +1,134 @@
+package testsuite
+
+import (
+	"fmt"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/iotaledger/hive.go/lo"
+	"github.com/iotaledger/iota-core/pkg/protocol"
+	"github.com/iotaledger/iota-core/pkg/protocol/engine/ledgerstate"
+	"github.com/iotaledger/iota-core/pkg/testsuite/mock"
+	iotago "github.com/iotaledger/iota.go/v4"
+	"github.com/iotaledger/iota.go/v4/builder"
+)
+
+type TransactionFramework struct {
+	api         iotago.API
+	protoParams *iotago.ProtocolParameters
+
+	wallet       *mock.HDWallet
+	states       map[string]*ledgerstate.Output
+	transactions map[string]*iotago.Transaction
+}
+
+func NewTransactionFramework(protocol *protocol.Protocol, genesisSeed []byte) *TransactionFramework {
+	genesisOutput, err := protocol.MainEngineInstance().Ledger.Output(iotago.OutputID{}.UTXOInput())
+	if err != nil {
+		panic(err)
+	}
+
+	return &TransactionFramework{
+		api:          protocol.API(),
+		protoParams:  protocol.MainEngineInstance().Storage.Settings().ProtocolParameters(),
+		states:       map[string]*ledgerstate.Output{"Genesis": genesisOutput},
+		transactions: make(map[string]*iotago.Transaction),
+		wallet:       mock.NewHDWallet("genesis", genesisSeed, 0),
+	}
+}
+
+func (t *TransactionFramework) CreateTransaction(alias string, outputCount int, inputAliases ...string) (*iotago.Transaction, error) {
+	inputStates := make([]*ledgerstate.Output, 0, len(inputAliases))
+	totalInputDeposits := uint64(0)
+	for _, inputAlias := range inputAliases {
+		output := t.Output(inputAlias)
+		inputStates = append(inputStates, output)
+		totalInputDeposits += output.Deposit()
+	}
+
+	tokenAmount := totalInputDeposits / uint64(outputCount)
+	remainderFunds := totalInputDeposits
+
+	outputStates := make(iotago.Outputs[iotago.Output], 0, outputCount)
+	for i := 0; i < outputCount; i++ {
+		if i+1 == outputCount {
+			tokenAmount = remainderFunds
+		}
+		remainderFunds -= tokenAmount
+
+		outputStates = append(outputStates, &iotago.BasicOutput{
+			Amount: tokenAmount,
+			Conditions: iotago.BasicOutputUnlockConditions{
+				&iotago.AddressUnlockCondition{Address: t.wallet.Address()},
+			},
+		})
+	}
+
+	transaction, err := t.CreateTransactionWithInputsAndOutputs(inputStates, outputStates, []*mock.HDWallet{t.wallet})
+	if err != nil {
+		panic(err)
+	}
+
+	lo.PanicOnErr(transaction.ID()).RegisterAlias(alias)
+
+	t.transactions[alias] = transaction
+
+	for idx, output := range outputStates {
+		t.states[fmt.Sprintf("%s:%d", alias, idx)] = ledgerstate.CreateOutput(t.api, iotago.OutputIDFromTransactionIDAndIndex(lo.PanicOnErr(transaction.ID()), uint16(idx)), iotago.EmptyBlockID(), 0, time.Now(), output)
+	}
+
+	return transaction, err
+}
+
+func (t *TransactionFramework) CreateTransactionWithInputsAndOutputs(consumedInputs ledgerstate.Outputs, outputs iotago.Outputs[iotago.Output], signingWallets []*mock.HDWallet) (*iotago.Transaction, error) {
+	walletKeys := make([]iotago.AddressKeys, len(signingWallets))
+	for i, wallet := range signingWallets {
+		inputPrivateKey, _ := wallet.KeyPair()
+		walletKeys[i] = iotago.AddressKeys{Address: wallet.Address(), Keys: inputPrivateKey}
+	}
+
+	txBuilder := builder.NewTransactionBuilder(t.protoParams.NetworkID())
+	for _, input := range consumedInputs {
+		switch input.OutputType() {
+		case iotago.OutputFoundry:
+			// For foundries we need to unlock the alias
+			txBuilder.AddInput(&builder.TxInput{UnlockTarget: input.Output().UnlockConditionSet().ImmutableAlias().Address, InputID: input.OutputID(), Input: input.Output()})
+		case iotago.OutputAlias:
+			// For alias we need to unlock the state controller
+			txBuilder.AddInput(&builder.TxInput{UnlockTarget: input.Output().UnlockConditionSet().StateControllerAddress().Address, InputID: input.OutputID(), Input: input.Output()})
+		default:
+			txBuilder.AddInput(&builder.TxInput{UnlockTarget: input.Output().UnlockConditionSet().Address().Address, InputID: input.OutputID(), Input: input.Output()})
+		}
+	}
+
+	for _, output := range outputs {
+		txBuilder.AddOutput(output)
+	}
+
+	return txBuilder.Build(t.protoParams, iotago.NewInMemoryAddressSigner(walletKeys...))
+}
+
+func (t *TransactionFramework) Output(alias string) *ledgerstate.Output {
+	output, exists := t.states[alias]
+	if !exists {
+		panic(xerrors.Errorf("output with given alias does not exist %s", alias))
+	}
+
+	return output
+}
+func (t *TransactionFramework) OutputID(alias string) iotago.OutputID {
+	return t.Output(alias).OutputID()
+}
+
+func (t *TransactionFramework) Transaction(alias string) *iotago.Transaction {
+	transaction, exists := t.transactions[alias]
+	if !exists {
+		panic(xerrors.Errorf("transaction with given alias does not exist %s", alias))
+	}
+
+	return transaction
+}
+func (t *TransactionFramework) TransactionID(alias string) iotago.TransactionID {
+	return lo.PanicOnErr(t.Transaction(alias).ID())
+}

--- a/pkg/testsuite/transactions_framework.go
+++ b/pkg/testsuite/transactions_framework.go
@@ -12,6 +12,7 @@ import (
 	"github.com/iotaledger/iota-core/pkg/testsuite/mock"
 	iotago "github.com/iotaledger/iota.go/v4"
 	"github.com/iotaledger/iota.go/v4/builder"
+	"github.com/iotaledger/iota.go/v4/tpkg"
 )
 
 type TransactionFramework struct {
@@ -105,6 +106,8 @@ func (t *TransactionFramework) CreateTransactionWithInputsAndOutputs(consumedInp
 	for _, output := range outputs {
 		txBuilder.AddOutput(output)
 	}
+	randomPayload := tpkg.Rand12ByteArray()
+	txBuilder.AddTaggedDataPayload(&iotago.TaggedData{Tag: randomPayload[:], Data: randomPayload[:]})
 
 	return txBuilder.Build(t.protoParams, iotago.NewInMemoryAddressSigner(walletKeys...))
 }


### PR DESCRIPTION
This PR introduces a framework that allows for easy creation of Stardust transactions without having to deal with the keys etc. The transaction-creation interface is the same as for mocked transaction in Goshimmer. 