### PR TITLE
Congestion Control: Accounts Filter only

### DIFF
--- a/components/protocol/component.go
+++ b/components/protocol/component.go
@@ -118,7 +118,7 @@ func provide(c *dig.Container) error {
 			),
 			protocol.WithFilterProvider(
 				blockfilter.NewProvider(
-					blockfilter.WithMinCommittableSlotAge(iotago.SlotIndex(ParamsProtocol.Notarization.MinSlotCommittableAge)),
+					blockfilter.WithMinCommittableAge(iotago.SlotIndex(ParamsProtocol.Notarization.MinSlotCommittableAge)),
 					blockfilter.WithMaxAllowedWallClockDrift(ParamsProtocol.Filter.MaxAllowedClockDrift),
 					blockfilter.WithSignatureValidation(true),
 				),

--- a/components/protocol/component.go
+++ b/components/protocol/component.go
@@ -120,7 +120,6 @@ func provide(c *dig.Container) error {
 				blockfilter.NewProvider(
 					blockfilter.WithMinCommittableAge(iotago.SlotIndex(ParamsProtocol.Notarization.MinSlotCommittableAge)),
 					blockfilter.WithMaxAllowedWallClockDrift(ParamsProtocol.Filter.MaxAllowedClockDrift),
-					blockfilter.WithSignatureValidation(true),
 				),
 			),
 		)

--- a/components/protocol/component.go
+++ b/components/protocol/component.go
@@ -142,7 +142,7 @@ func configure() error {
 		Component.LogInfof("BlockReceived: %s", block.ID())
 	})
 
-	deps.Protocol.Events.Engine.Filter.BlockFiltered.Hook(func(event *filter.BlockFilteredEvent) {
+	deps.Protocol.Events.Engine.Filter.BlockPreFiltered.Hook(func(event *filter.BlockPreFilteredEvent) {
 		Component.LogInfof("BlockFiltered: %s - %s", event.Block.ID(), event.Reason.Error())
 	})
 

--- a/pkg/protocol/engine/blockdag/inmemoryblockdag/blockdag.go
+++ b/pkg/protocol/engine/blockdag/inmemoryblockdag/blockdag.go
@@ -7,9 +7,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/iotaledger/hive.go/core/causalorder"
-	"github.com/iotaledger/hive.go/core/memstorage"
-	"github.com/iotaledger/hive.go/ds/advancedset"
-	"github.com/iotaledger/hive.go/lo"
 	"github.com/iotaledger/hive.go/runtime/event"
 	"github.com/iotaledger/hive.go/runtime/module"
 	"github.com/iotaledger/hive.go/runtime/options"
@@ -19,7 +16,6 @@ import (
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/blockdag"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/blocks"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/eviction"
-	"github.com/iotaledger/iota-core/pkg/protocol/engine/notarization"
 	iotago "github.com/iotaledger/iota.go/v4"
 )
 
@@ -34,24 +30,9 @@ type BlockDAG struct {
 	// solidifier contains the solidifier instance used to determine the solidity of Blocks.
 	solidifier *causalorder.CausalOrder[iotago.SlotIndex, iotago.BlockID, *blocks.Block]
 
-	// commitmentFunc is a function that returns the commitment corresponding to the given slot index.
-	commitmentFunc func(index iotago.SlotIndex) (*model.Commitment, error)
-
-	// futureBlocks contains blocks with a commitment in the future, that should not be passed to the booker yet.
-	futureBlocks *memstorage.IndexedStorage[iotago.SlotIndex, iotago.CommitmentID, *advancedset.AdvancedSet[*blocks.Block]]
-
-	nextIndexToPromote iotago.SlotIndex
-
 	blockCache *blocks.Blocks
 
-	// The Queue always read-locks the eviction mutex of the solidifier, and then evaluates if the block is
-	// future thus read-locking the futureBlocks mutex. At the same time, when re-adding parked blocks,
-	// promoteFutureBlocksMethod write-locks the futureBlocks mutex, and then read-locks the eviction mutex
-	// of the solidifier. As the locks are non-starving, and locks are interlocked in different orders a
-	// deadlock can occur only when an eviction is triggered while the above scenario unfolds.
 	solidifierMutex sync.RWMutex
-
-	futureBlocksMutex sync.RWMutex
 
 	workers    *workerpool.Group
 	workerPool *workerpool.WorkerPool
@@ -63,7 +44,7 @@ type BlockDAG struct {
 
 func NewProvider(opts ...options.Option[BlockDAG]) module.Provider[*engine.Engine, blockdag.BlockDAG] {
 	return module.Provide(func(e *engine.Engine) blockdag.BlockDAG {
-		b := New(e.Workers.CreateGroup("BlockDAG"), e.EvictionState, e.BlockCache, e.Storage.Commitments().Load, e.ErrorHandler("blockdag"), opts...)
+		b := New(e.Workers.CreateGroup("BlockDAG"), e.EvictionState, e.BlockCache, e.ErrorHandler("blockdag"), opts...)
 
 		e.HookConstructed(func() {
 			wp := b.workers.CreatePool("BlockDAG.Attach", 2)
@@ -72,10 +53,6 @@ func NewProvider(opts ...options.Option[BlockDAG]) module.Provider[*engine.Engin
 				if _, _, err := b.Attach(block); err != nil {
 					b.errorHandler(errors.Wrapf(err, "failed to attach block with %s (issuerID: %s)", block.ID(), block.Block().IssuerID))
 				}
-			}, event.WithWorkerPool(wp))
-
-			e.Events.Notarization.SlotCommitted.Hook(func(details *notarization.SlotCommittedDetails) {
-				b.PromoteFutureBlocksUntil(details.Commitment.Index())
 			}, event.WithWorkerPool(wp))
 
 			e.Events.BlockDAG.LinkTo(b.events)
@@ -88,16 +65,14 @@ func NewProvider(opts ...options.Option[BlockDAG]) module.Provider[*engine.Engin
 }
 
 // New is the constructor for the BlockDAG and creates a new BlockDAG instance.
-func New(workers *workerpool.Group, evictionState *eviction.State, blockCache *blocks.Blocks, latestCommitmentFunc func(iotago.SlotIndex) (*model.Commitment, error), errorHandler func(error), opts ...options.Option[BlockDAG]) (newBlockDAG *BlockDAG) {
+func New(workers *workerpool.Group, evictionState *eviction.State, blockCache *blocks.Blocks, errorHandler func(error), opts ...options.Option[BlockDAG]) (newBlockDAG *BlockDAG) {
 	return options.Apply(&BlockDAG{
-		events:         blockdag.NewEvents(),
-		evictionState:  evictionState,
-		commitmentFunc: latestCommitmentFunc,
-		blockCache:     blockCache,
-		futureBlocks:   memstorage.NewIndexedStorage[iotago.SlotIndex, iotago.CommitmentID, *advancedset.AdvancedSet[*blocks.Block]](),
-		workers:        workers,
-		workerPool:     workers.CreatePool("Solidifier", 2),
-		errorHandler:   errorHandler,
+		events:        blockdag.NewEvents(),
+		evictionState: evictionState,
+		blockCache:    blockCache,
+		workers:       workers,
+		workerPool:    workers.CreatePool("Solidifier", 2),
+		errorHandler:  errorHandler,
 	}, opts,
 		func(b *BlockDAG) {
 			b.solidifier = causalorder.New(
@@ -142,31 +117,6 @@ func (b *BlockDAG) SetInvalid(block *blocks.Block, reason error) (wasUpdated boo
 	return
 }
 
-func (b *BlockDAG) PromoteFutureBlocksUntil(index iotago.SlotIndex) {
-	b.solidifierMutex.RLock()
-	defer b.solidifierMutex.RUnlock()
-	b.futureBlocksMutex.Lock()
-	defer b.futureBlocksMutex.Unlock()
-
-	for i := b.nextIndexToPromote; i <= index; i++ {
-		cm, err := b.commitmentFunc(i)
-		if err != nil {
-			panic(fmt.Sprintf("failed to load commitment for index %d: %s", i, err))
-		}
-		if storage := b.futureBlocks.Get(i, false); storage != nil {
-			if futureBlocks, exists := storage.Get(cm.ID()); exists {
-				_ = futureBlocks.ForEach(func(futureBlock *blocks.Block) (err error) {
-					b.solidifier.Queue(futureBlock)
-					return nil
-				})
-			}
-		}
-		b.futureBlocks.Evict(i)
-	}
-
-	b.nextIndexToPromote = index + 1
-}
-
 func (b *BlockDAG) Shutdown() {
 	b.TriggerStopped()
 	b.workers.Shutdown()
@@ -181,47 +131,11 @@ func (b *BlockDAG) evictSlot(index iotago.SlotIndex) {
 }
 
 func (b *BlockDAG) markSolid(block *blocks.Block) (err error) {
-	// Future blocks already have passed these checks, as they are revisited again at a later point in time.
-	// It is important to note that this check only passes once for a specific future block, as it is not yet marked as
-	// such. The next time the block is added to the causal order and marked as solid (that is, when it got promoted),
-	// it will be marked solid straight away, without checking if it is still a future block: that's why this method
-	// must be only called at most twice for any block.
-	if !block.IsFuture() {
-		if err := b.checkParents(block); err != nil {
-			return err
-		}
-
-		if b.isFutureBlock(block) {
-			return
-		}
-	}
-
-	// It is important to only set the block as solid when it was not "parked" as a future block.
-	// Future blocks are queued for solidification again when the slot is committed.
 	if block.SetSolid() {
 		b.events.BlockSolid.Trigger(block)
 	}
 
 	return nil
-}
-
-func (b *BlockDAG) isFutureBlock(block *blocks.Block) (isFutureBlock bool) {
-	b.futureBlocksMutex.RLock()
-	defer b.futureBlocksMutex.RUnlock()
-
-	// If we are not able to load the commitment for the block, it means we haven't committed this slot yet.
-	if _, err := b.commitmentFunc(block.SlotCommitmentID().Index()); err != nil {
-		// We set the block as future block so that we can skip some checks when revisiting it later in markSolid via the solidifier.
-		block.SetFuture()
-
-		lo.Return1(b.futureBlocks.Get(block.Block().SlotCommitment.Index, true).GetOrCreate(block.Block().SlotCommitment.MustID(), func() *advancedset.AdvancedSet[*blocks.Block] {
-			return advancedset.New[*blocks.Block]()
-		})).Add(block)
-
-		return true
-	}
-
-	return false
 }
 
 func (b *BlockDAG) checkParents(block *blocks.Block) (err error) {

--- a/pkg/protocol/engine/commitmentfilter/accountsfilter/commitmentfilter.go
+++ b/pkg/protocol/engine/commitmentfilter/accountsfilter/commitmentfilter.go
@@ -1,1 +1,114 @@
 package accountsfilter
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/iotaledger/hive.go/core/memstorage"
+	"github.com/iotaledger/hive.go/ds/advancedset"
+	"github.com/iotaledger/hive.go/lo"
+	"github.com/iotaledger/hive.go/runtime/module"
+	"github.com/iotaledger/hive.go/runtime/options"
+	"github.com/iotaledger/iota-core/pkg/model"
+	"github.com/iotaledger/iota-core/pkg/protocol/engine"
+	"github.com/iotaledger/iota-core/pkg/protocol/engine/accounts"
+	"github.com/iotaledger/iota-core/pkg/protocol/engine/commitmentfilter"
+	"github.com/iotaledger/iota-core/pkg/protocol/engine/notarization"
+	iotago "github.com/iotaledger/iota.go/v4"
+)
+
+type CommitmentFilter struct {
+	// Events contains the Events of the CommitmentFilter
+	events *commitmentfilter.Events
+	// futureBlocks contains blocks with a commitment in the future, that should not be passed to the blockdag yet.
+	futureBlocks *memstorage.IndexedStorage[iotago.SlotIndex, iotago.CommitmentID, *advancedset.AdvancedSet[*model.Block]]
+
+	// commitmentFunc is a function that returns the commitment corresponding to the given slot index.
+	commitmentFunc func(iotago.SlotIndex) (*model.Commitment, error)
+
+	accountRetrieveFunc func(accountID iotago.AccountID, targetIndex iotago.SlotIndex) (accountData *accounts.AccountData, exists bool, err error)
+
+	futureBlocksMutex sync.RWMutex
+
+	nextIndexToPromote iotago.SlotIndex
+
+	module.Module
+}
+
+func NewProvider(opts ...options.Option[CommitmentFilter]) module.Provider[*engine.Engine, commitmentfilter.CommitmentFilter] {
+	return module.Provide(func(e *engine.Engine) commitmentfilter.CommitmentFilter {
+		// TODO: check the accounts manager directly rather than loading the commitment from storage.
+		c := New(e.Storage.Commitments().Load, e.Ledger.Account, opts...)
+		e.HookConstructed(func() {
+			e.Events.Notarization.SlotCommitted.Hook(func(details *notarization.SlotCommittedDetails) {
+				c.PromoteFutureBlocksUntil(details.Commitment.Index())
+			})
+
+			e.Events.CommitmentFilter.LinkTo(c.events)
+
+			c.TriggerInitialized()
+		})
+
+		return c
+	})
+}
+
+func New(commitmentFunc func(iotago.SlotIndex) (*model.Commitment, error), accountRetrieveFunc func(accountID iotago.AccountID, targetIndex iotago.SlotIndex) (accountData *accounts.AccountData, exists bool, err error), opts ...options.Option[CommitmentFilter]) *CommitmentFilter {
+	return options.Apply(&CommitmentFilter{
+		futureBlocks:        memstorage.NewIndexedStorage[iotago.SlotIndex, iotago.CommitmentID, *advancedset.AdvancedSet[*model.Block]](),
+		commitmentFunc:      commitmentFunc,
+		accountRetrieveFunc: accountRetrieveFunc,
+	}, opts,
+	)
+}
+
+func (c *CommitmentFilter) PromoteFutureBlocksUntil(index iotago.SlotIndex) {
+	c.futureBlocksMutex.Lock()
+	defer c.futureBlocksMutex.Unlock()
+
+	for i := c.nextIndexToPromote; i <= index; i++ {
+		cm, err := c.commitmentFunc(i)
+		if err != nil {
+			panic(fmt.Sprintf("failed to load commitment for index %d: %s", i, err))
+		}
+		if storage := c.futureBlocks.Get(i, false); storage != nil {
+			if futureBlocks, exists := storage.Get(cm.ID()); exists {
+				_ = futureBlocks.ForEach(func(futureBlock *model.Block) (err error) {
+					// TODO: filter here.
+					return nil
+				})
+			}
+		}
+		c.futureBlocks.Evict(i)
+	}
+
+	c.nextIndexToPromote = index + 1
+}
+
+func (c *CommitmentFilter) isFutureBlock(block *model.Block) (isFutureBlock bool) {
+	c.futureBlocksMutex.RLock()
+	defer c.futureBlocksMutex.RUnlock()
+
+	// If we are not able to load the commitment for the block, it means we haven't committed this slot yet.
+	if _, err := c.commitmentFunc(block.SlotCommitment().Index()); err != nil {
+		lo.Return1(c.futureBlocks.Get(block.SlotCommitment().Index(), true).GetOrCreate(block.Block().SlotCommitment.MustID(), func() *advancedset.AdvancedSet[*model.Block] {
+			return advancedset.New[*model.Block]()
+		})).Add(block)
+
+		return true
+	}
+
+	return false
+}
+
+func (c *CommitmentFilter) ProcessPreFilteredBlock(block *model.Block) {
+	if c.isFutureBlock(block) {
+		return
+	}
+
+	c.events.BlockAllowed.Trigger(block)
+}
+
+func (c *CommitmentFilter) Shutdown() {
+	c.TriggerStopped()
+}

--- a/pkg/protocol/engine/commitmentfilter/accountsfilter/commitmentfilter.go
+++ b/pkg/protocol/engine/commitmentfilter/accountsfilter/commitmentfilter.go
@@ -1,0 +1,1 @@
+package accountsfilter

--- a/pkg/protocol/engine/commitmentfilter/accountsfilter/commitmentfilter_test.go
+++ b/pkg/protocol/engine/commitmentfilter/accountsfilter/commitmentfilter_test.go
@@ -1,0 +1,1 @@
+package accountsfilter

--- a/pkg/protocol/engine/commitmentfilter/commitmentfilter.go
+++ b/pkg/protocol/engine/commitmentfilter/commitmentfilter.go
@@ -3,12 +3,11 @@ package commitmentfilter
 import (
 	"github.com/iotaledger/hive.go/runtime/module"
 	"github.com/iotaledger/iota-core/pkg/model"
-	"github.com/iotaledger/iota-core/pkg/network"
 )
 
 type CommitmentFilter interface {
 	// ProcessFilteredBlock processes block from the given source.
-	ProcessPreFilteredBlock(block *model.Block, source network.PeerID)
+	ProcessPreFilteredBlock(block *model.Block)
 
 	module.Interface
 }

--- a/pkg/protocol/engine/commitmentfilter/commitmentfilter.go
+++ b/pkg/protocol/engine/commitmentfilter/commitmentfilter.go
@@ -1,0 +1,14 @@
+package commitmentfilter
+
+import (
+	"github.com/iotaledger/hive.go/runtime/module"
+	"github.com/iotaledger/iota-core/pkg/model"
+	"github.com/iotaledger/iota-core/pkg/network"
+)
+
+type CommitmentFilter interface {
+	// ProcessFilteredBlock processes block from the given source.
+	ProcessPreFilteredBlock(block *model.Block, source network.PeerID)
+
+	module.Interface
+}

--- a/pkg/protocol/engine/commitmentfilter/events.go
+++ b/pkg/protocol/engine/commitmentfilter/events.go
@@ -3,7 +3,6 @@ package commitmentfilter
 import (
 	"github.com/iotaledger/hive.go/runtime/event"
 	"github.com/iotaledger/iota-core/pkg/model"
-	"github.com/iotaledger/iota-core/pkg/network"
 )
 
 type Events struct {
@@ -23,5 +22,4 @@ var NewEvents = event.CreateGroupConstructor(func() *Events {
 type BlockFilteredEvent struct {
 	Block  *model.Block
 	Reason error
-	Source network.PeerID
 }

--- a/pkg/protocol/engine/commitmentfilter/events.go
+++ b/pkg/protocol/engine/commitmentfilter/events.go
@@ -1,4 +1,4 @@
-package filter
+package commitmentfilter
 
 import (
 	"github.com/iotaledger/hive.go/runtime/event"
@@ -7,20 +7,20 @@ import (
 )
 
 type Events struct {
-	BlockPreFiltered *event.Event1[*BlockPreFilteredEvent]
-	BlockPreAllowed  *event.Event1[*model.Block]
+	BlockFiltered *event.Event1[*BlockFilteredEvent]
+	BlockAllowed  *event.Event1[*model.Block]
 
 	event.Group[Events, *Events]
 }
 
 var NewEvents = event.CreateGroupConstructor(func() *Events {
 	return &Events{
-		BlockPreFiltered: event.New1[*BlockPreFilteredEvent](),
-		BlockPreAllowed:  event.New1[*model.Block](),
+		BlockFiltered: event.New1[*BlockFilteredEvent](),
+		BlockAllowed:  event.New1[*model.Block](),
 	}
 })
 
-type BlockPreFilteredEvent struct {
+type BlockFilteredEvent struct {
 	Block  *model.Block
 	Reason error
 	Source network.PeerID

--- a/pkg/protocol/engine/engine.go
+++ b/pkg/protocol/engine/engine.go
@@ -23,6 +23,7 @@ import (
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/blocks"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/booker"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/clock"
+	"github.com/iotaledger/iota-core/pkg/protocol/engine/commitmentfilter"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/consensus/blockgadget"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/consensus/slotgadget"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/eviction"
@@ -38,21 +39,22 @@ import (
 // region Engine /////////////////////////////////////////////////////////////////////////////////////////////////////
 
 type Engine struct {
-	Events          *Events
-	Storage         *storage.Storage
-	Filter          filter.Filter
-	EvictionState   *eviction.State
-	BlockRequester  *eventticker.EventTicker[iotago.SlotIndex, iotago.BlockID]
-	BlockDAG        blockdag.BlockDAG
-	Booker          booker.Booker
-	Clock           clock.Clock
-	SybilProtection sybilprotection.SybilProtection
-	BlockGadget     blockgadget.Gadget
-	SlotGadget      slotgadget.Gadget
-	Notarization    notarization.Notarization
-	Attestations    attestation.Attestations
-	Ledger          ledger.Ledger
-	TipManager      tipmanager.TipManager
+	Events           *Events
+	Storage          *storage.Storage
+	Filter           filter.Filter
+	CommitmentFilter commitmentfilter.CommitmentFilter
+	EvictionState    *eviction.State
+	BlockRequester   *eventticker.EventTicker[iotago.SlotIndex, iotago.BlockID]
+	BlockDAG         blockdag.BlockDAG
+	Booker           booker.Booker
+	Clock            clock.Clock
+	SybilProtection  sybilprotection.SybilProtection
+	BlockGadget      blockgadget.Gadget
+	SlotGadget       slotgadget.Gadget
+	Notarization     notarization.Notarization
+	Attestations     attestation.Attestations
+	Ledger           ledger.Ledger
+	TipManager       tipmanager.TipManager
 
 	Workers      *workerpool.Group
 	errorHandler func(error)

--- a/pkg/protocol/engine/events.go
+++ b/pkg/protocol/engine/events.go
@@ -6,6 +6,7 @@ import (
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/blockdag"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/booker"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/clock"
+	"github.com/iotaledger/iota-core/pkg/protocol/engine/commitmentfilter"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/consensus/blockgadget"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/consensus/slotgadget"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/eviction"
@@ -21,19 +22,20 @@ import (
 type Events struct {
 	BlockProcessed *event.Event1[iotago.BlockID]
 
-	EvictionState   *eviction.Events
-	Filter          *filter.Events
-	BlockRequester  *eventticker.Events[iotago.SlotIndex, iotago.BlockID]
-	TipManager      *tipmanager.Events
-	BlockDAG        *blockdag.Events
-	Booker          *booker.Events
-	Clock           *clock.Events
-	BlockGadget     *blockgadget.Events
-	SlotGadget      *slotgadget.Events
-	Ledger          *ledger.Events
-	Notarization    *notarization.Events
-	ConflictDAG     *conflictdag.Events[iotago.TransactionID, iotago.OutputID]
-	SybilProtection *sybilprotection.Events
+	EvictionState    *eviction.Events
+	Filter           *filter.Events
+	CommitmentFilter *commitmentfilter.Events
+	BlockRequester   *eventticker.Events[iotago.SlotIndex, iotago.BlockID]
+	TipManager       *tipmanager.Events
+	BlockDAG         *blockdag.Events
+	Booker           *booker.Events
+	Clock            *clock.Events
+	BlockGadget      *blockgadget.Events
+	SlotGadget       *slotgadget.Events
+	Ledger           *ledger.Events
+	Notarization     *notarization.Events
+	ConflictDAG      *conflictdag.Events[iotago.TransactionID, iotago.OutputID]
+	SybilProtection  *sybilprotection.Events
 
 	event.Group[Events, *Events]
 }

--- a/pkg/protocol/engine/filter/blockfilter/filter_test.go
+++ b/pkg/protocol/engine/filter/blockfilter/filter_test.go
@@ -34,12 +34,12 @@ func NewTestFramework(t *testing.T, protocolParams *iotago.ProtocolParameters, o
 		}, optsFilter...),
 	}
 
-	tf.Filter.events.BlockAllowed.Hook(func(block *model.Block) {
-		t.Logf("BlockAllowed: %s", block.ID())
+	tf.Filter.events.BlockPreAllowed.Hook(func(block *model.Block) {
+		t.Logf("BlockPreAllowed: %s", block.ID())
 	})
 
-	tf.Filter.events.BlockFiltered.Hook(func(event *filter.BlockFilteredEvent) {
-		t.Logf("BlockFiltered: %s - %s", event.Block.ID(), event.Reason)
+	tf.Filter.events.BlockPreFiltered.Hook(func(event *filter.BlockPreFilteredEvent) {
+		t.Logf("BlockPreFiltered: %s - %s", event.Block.ID(), event.Reason)
 	})
 
 	return tf
@@ -143,11 +143,11 @@ func TestFilter_WithMaxAllowedWallClockDrift(t *testing.T) {
 		WithSignatureValidation(false),
 	)
 
-	tf.Filter.events.BlockAllowed.Hook(func(block *model.Block) {
+	tf.Filter.events.BlockPreAllowed.Hook(func(block *model.Block) {
 		require.NotEqual(t, "tooFarAheadFuture", block.ID().Alias())
 	})
 
-	tf.Filter.events.BlockFiltered.Hook(func(event *filter.BlockFilteredEvent) {
+	tf.Filter.events.BlockPreFiltered.Hook(func(event *filter.BlockPreFilteredEvent) {
 		require.Equal(t, "tooFarAheadFuture", event.Block.ID().Alias())
 		require.True(t, errors.Is(event.Reason, ErrBlockTimeTooFarAheadInFuture))
 	})
@@ -164,11 +164,11 @@ func TestFilter_WithSignatureValidation(t *testing.T) {
 		WithSignatureValidation(true),
 	)
 
-	tf.Filter.events.BlockAllowed.Hook(func(block *model.Block) {
+	tf.Filter.events.BlockPreAllowed.Hook(func(block *model.Block) {
 		require.Equal(t, "valid", block.ID().Alias())
 	})
 
-	tf.Filter.events.BlockFiltered.Hook(func(event *filter.BlockFilteredEvent) {
+	tf.Filter.events.BlockPreFiltered.Hook(func(event *filter.BlockPreFilteredEvent) {
 		require.Equal(t, "invalid", event.Block.ID().Alias())
 		require.True(t, errors.Is(event.Reason, ErrInvalidSignature))
 	})
@@ -187,11 +187,11 @@ func TestFilter_MinCommittableSlotAge(t *testing.T) {
 		WithSignatureValidation(false),
 	)
 
-	tf.Filter.events.BlockAllowed.Hook(func(block *model.Block) {
+	tf.Filter.events.BlockPreAllowed.Hook(func(block *model.Block) {
 		require.True(t, strings.HasPrefix(block.ID().Alias(), "valid"))
 	})
 
-	tf.Filter.events.BlockFiltered.Hook(func(event *filter.BlockFilteredEvent) {
+	tf.Filter.events.BlockPreFiltered.Hook(func(event *filter.BlockPreFilteredEvent) {
 		require.True(t, strings.HasPrefix(event.Block.ID().Alias(), "invalid"))
 		require.True(t, errors.Is(event.Reason, ErrCommitmentNotCommittable))
 	})
@@ -225,11 +225,11 @@ func TestFilter_MinPoW(t *testing.T) {
 		WithSignatureValidation(false),
 	)
 
-	tf.Filter.events.BlockAllowed.Hook(func(block *model.Block) {
+	tf.Filter.events.BlockPreAllowed.Hook(func(block *model.Block) {
 		require.True(t, strings.HasPrefix(block.ID().Alias(), "valid"))
 	})
 
-	tf.Filter.events.BlockFiltered.Hook(func(event *filter.BlockFilteredEvent) {
+	tf.Filter.events.BlockPreFiltered.Hook(func(event *filter.BlockPreFilteredEvent) {
 		require.True(t, strings.HasPrefix(event.Block.ID().Alias(), "invalid"))
 		require.True(t, errors.Is(event.Reason, ErrInvalidProofOfWork))
 	})

--- a/pkg/tests/protocol_startup_test.go
+++ b/pkg/tests/protocol_startup_test.go
@@ -152,7 +152,7 @@ func TestProtocol_StartNodeFromSnapshotAndDisk(t *testing.T) {
 		ts.AssertBlocksInCacheAccepted(ts.Blocks("3.1"), true, ts.Nodes()...)
 		ts.AssertBlocksInCacheConfirmed(ts.Blocks("3.1"), false, ts.Nodes()...) // too old. confirmation ratification threshold = 2
 
-		// Verify nodes' states: Slot 1 should be committed as the MinCommittableSlotAge is 1, and we accepted a block at slot 3.
+		// Verify nodes' states: Slot 1 should be committed as the MinCommittableAge is 1, and we accepted a block at slot 3.
 		ts.AssertNodeState(ts.Nodes(),
 			testsuite.WithSnapshotImported(true),
 			testsuite.WithProtocolParameters(ts.ProtocolParameters),
@@ -188,7 +188,7 @@ func TestProtocol_StartNodeFromSnapshotAndDisk(t *testing.T) {
 		ts.AssertBlocksInCacheConfirmed(ts.Blocks("4.2", "5.1"), false, ts.Nodes()...) // too old. confirmation ratification threshold = 2
 
 		// Verify nodes' states:
-		// - Slot 3 should be committed as the MinCommittableSlotAge is 1, and we accepted a block at slot 5.
+		// - Slot 3 should be committed as the MinCommittableAge is 1, and we accepted a block at slot 5.
 		// - 5.1 is accepted and commits to slot 1 -> slot 1 should be evicted.
 		// - rootblocks are still not evicted as RootBlocksEvictionDelay is 3.
 		// - slot 1 is still not finalized: there is no supermajority of confirmed blocks that commits to it.
@@ -231,7 +231,7 @@ func TestProtocol_StartNodeFromSnapshotAndDisk(t *testing.T) {
 		ts.AssertBlocksInCacheConfirmed(ts.Blocks("8.2", "9.1.2"), true, ts.Nodes()...)
 
 		// Verify nodes' states:
-		// - Slot 3 should be committed as the MinCommittableSlotAge is 1, and we accepted a block at slot 5.
+		// - Slot 3 should be committed as the MinCommittableAge is 1, and we accepted a block at slot 5.
 		ts.AssertNodeState(ts.Nodes(),
 			testsuite.WithSnapshotImported(true),
 			testsuite.WithProtocolParameters(ts.ProtocolParameters),
@@ -272,7 +272,7 @@ func TestProtocol_StartNodeFromSnapshotAndDisk(t *testing.T) {
 		ts.AssertBlocksInCacheConfirmed(ts.Blocks("9.1.2", "9.2.2", "9.1.3", "9.2.3"), true, ts.Nodes()...) // too old. confirmation ratification threshold = 2
 
 		// Verify nodes' states:
-		// - Slot 7 should be committed as the MinCommittableSlotAge is 1, and we accepted a block at slot 9.
+		// - Slot 7 should be committed as the MinCommittableAge is 1, and we accepted a block at slot 9.
 		// - rootblocks are evicted until slot 5 as RootBlocksEvictionDelay is 3.
 		// - slot 3 is finalized as "9.1.2", "9.2.2", "9.1.3", "9.2.3" are confirmed within slot 9 being a supermajority.
 		ts.AssertNodeState(ts.Nodes(),
@@ -317,7 +317,7 @@ func TestProtocol_StartNodeFromSnapshotAndDisk(t *testing.T) {
 		ts.AssertBlocksInCacheConfirmed(ts.Blocks("11.1", "12.2", "12.1"), true, ts.Nodes()...)
 
 		// Verify nodes' states:
-		// - Slot 10 should be committed as the MinCommittableSlotAge is 1, and we accepted a block at slot 12.
+		// - Slot 10 should be committed as the MinCommittableAge is 1, and we accepted a block at slot 12.
 		// - rootblocks are evicted until slot 8 as RootBlocksEvictionDelay is 3.
 		// - Slot 7 is finalized: there is a supermajority of confirmed blocks that commits to it.
 		ts.AssertNodeState(ts.Nodes(),
@@ -359,7 +359,7 @@ func TestProtocol_StartNodeFromSnapshotAndDisk(t *testing.T) {
 		ts.AssertBlocksInCacheConfirmed(ts.Blocks("12.2", "12.1"), true, ts.Nodes()...)
 
 		// Verify nodes' states:
-		// - Slot 10 should be committed as the MinCommittableSlotAge is 1, and we accepted a block at slot 12.
+		// - Slot 10 should be committed as the MinCommittableAge is 1, and we accepted a block at slot 12.
 		ts.AssertNodeState(ts.Nodes(),
 			testsuite.WithSnapshotImported(true),
 			testsuite.WithProtocolParameters(ts.ProtocolParameters),
@@ -664,7 +664,7 @@ func TestProtocol_StartNodeFromSnapshotAndDiskWithEmptySlot(t *testing.T) {
 		ts.AssertBlocksInCacheAccepted(ts.Blocks("3.1"), true, ts.Nodes()...)
 		ts.AssertBlocksInCacheConfirmed(ts.Blocks("3.1"), false, ts.Nodes()...) // too old. confirmation ratification threshold = 2
 
-		// Verify nodes' states: Slot 1 should be committed as the MinCommittableSlotAge is 1, and we accepted a block at slot 3.
+		// Verify nodes' states: Slot 1 should be committed as the MinCommittableAge is 1, and we accepted a block at slot 3.
 		ts.AssertNodeState(ts.Nodes(),
 			testsuite.WithSnapshotImported(true),
 			testsuite.WithProtocolParameters(ts.ProtocolParameters),
@@ -701,7 +701,7 @@ func TestProtocol_StartNodeFromSnapshotAndDiskWithEmptySlot(t *testing.T) {
 		ts.AssertBlocksInCacheConfirmed(ts.Blocks("4.2", "5.1"), false, ts.Nodes()...) // too old. confirmation ratification threshold = 2
 
 		// Verify nodes' states:
-		// - Slot 3 should be committed as the MinCommittableSlotAge is 1, and we accepted a block at slot 5.
+		// - Slot 3 should be committed as the MinCommittableAge is 1, and we accepted a block at slot 5.
 		// - 5.1 is accepted and commits to slot 1 -> slot 1 should be evicted.
 		// - rootblocks are still not evicted as RootBlocksEvictionDelay is 3.
 		// - slot 1 is still not finalized: there is no supermajority of confirmed blocks that commits to it.
@@ -744,7 +744,7 @@ func TestProtocol_StartNodeFromSnapshotAndDiskWithEmptySlot(t *testing.T) {
 		ts.AssertBlocksInCacheConfirmed(ts.Blocks("9.2", "10.1.2"), true, ts.Nodes()...)
 
 		// Verify nodes' states:
-		// - Slot 3 should be committed as the MinCommittableSlotAge is 1, and we accepted a block at slot 5.
+		// - Slot 3 should be committed as the MinCommittableAge is 1, and we accepted a block at slot 5.
 		ts.AssertNodeState(ts.Nodes(),
 			testsuite.WithSnapshotImported(true),
 			testsuite.WithProtocolParameters(ts.ProtocolParameters),
@@ -785,7 +785,7 @@ func TestProtocol_StartNodeFromSnapshotAndDiskWithEmptySlot(t *testing.T) {
 		ts.AssertBlocksInCacheConfirmed(ts.Blocks("10.1.2", "10.2.2", "10.1.3", "10.2.3"), true, ts.Nodes()...) // too old. confirmation ratification threshold = 2
 
 		// Verify nodes' states:
-		// - Slot 8 should be committed as the MinCommittableSlotAge is 1, and we accepted a block at slot 10.
+		// - Slot 8 should be committed as the MinCommittableAge is 1, and we accepted a block at slot 10.
 		// - rootblocks are evicted until slot 5 as RootBlocksEvictionDelay is 3.
 		// - slot 3 is finalized as "10.1.2", "10.2.2", "10.1.3", "10.2.3" are confirmed within slot 9 being a supermajority.
 		ts.AssertNodeState(ts.Nodes(),
@@ -830,7 +830,7 @@ func TestProtocol_StartNodeFromSnapshotAndDiskWithEmptySlot(t *testing.T) {
 		ts.AssertBlocksInCacheConfirmed(ts.Blocks("12.1", "13.2", "13.1"), true, ts.Nodes()...)
 
 		// Verify nodes' states:
-		// - Slot 10 should be committed as the MinCommittableSlotAge is 1, and we accepted a block at slot 12.
+		// - Slot 10 should be committed as the MinCommittableAge is 1, and we accepted a block at slot 12.
 		// - rootblocks are evicted until slot 8 as RootBlocksEvictionDelay is 3.
 		// - slot 7 is finalized: there is a supermajority of confirmed blocks that commits to it.
 		ts.AssertNodeState(ts.Nodes(),
@@ -872,7 +872,7 @@ func TestProtocol_StartNodeFromSnapshotAndDiskWithEmptySlot(t *testing.T) {
 		ts.AssertBlocksInCacheConfirmed(ts.Blocks("13.2", "13.1"), true, ts.Nodes()...)
 
 		// Verify nodes' states:
-		// - Slot 11 should be committed as the MinCommittableSlotAge is 1, and we accepted a block at slot 13.
+		// - Slot 11 should be committed as the MinCommittableAge is 1, and we accepted a block at slot 13.
 		ts.AssertNodeState(ts.Nodes(),
 			testsuite.WithSnapshotImported(true),
 			testsuite.WithProtocolParameters(ts.ProtocolParameters),

--- a/pkg/testsuite/mock/node.go
+++ b/pkg/testsuite/mock/node.go
@@ -248,11 +248,11 @@ func (n *Node) attachEngineLogs(instance *engine.Engine) {
 		fmt.Printf("%s > [%s] Clock.ConfirmedTimeUpdated: %s [Slot %d]\n", n.Name, engineName, newTime, instance.API().TimeProvider().SlotIndexFromTime(newTime))
 	})
 
-	events.Filter.BlockAllowed.Hook(func(block *model.Block) {
-		fmt.Printf("%s > [%s] Filter.BlockAllowed: %s\n", n.Name, engineName, block.ID())
+	events.Filter.BlockPreAllowed.Hook(func(block *model.Block) {
+		fmt.Printf("%s > [%s] Filter.BlockPreAllowed: %s\n", n.Name, engineName, block.ID())
 	})
 
-	events.Filter.BlockFiltered.Hook(func(event *filter.BlockFilteredEvent) {
+	events.Filter.BlockPreFiltered.Hook(func(event *filter.BlockPreFilteredEvent) {
 		fmt.Printf("%s > [%s] Filter.BlockFiltered: %s - %s\n", n.Name, engineName, event.Block.ID(), event.Reason.Error())
 		n.Testing.Fatal("no blocks should be filtered")
 	})


### PR DESCRIPTION
This adds a new module - the accounts filter.

The accounts filter takes care of filter checks which rely on account information from the account manager which in turns relies on commitments. The checks include BIC, signature verification (including that the key used to sign the block is actually registered to the account), burned Mana check (which relies on RMC and hence commitments).

The accounts filter also deals with "future blocks" whose commitments are not yet available to a node. Future blocks were dealt with in the BlockDAG, but they are no longer required there as the accounts filter sits before the BlockDAG.