### PR TITLE
Adapt to changes of version type in iota.go and make version deserialization safe

### DIFF
--- a/components/dashboard/explorer_routes.go
+++ b/components/dashboard/explorer_routes.go
@@ -6,6 +6,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"github.com/iotaledger/hive.go/ierrors"
+	"github.com/iotaledger/hive.go/lo"
 	"github.com/iotaledger/inx-app/pkg/httpserver"
 	"github.com/iotaledger/iota-core/pkg/model"
 	"github.com/iotaledger/iota-core/pkg/restapi"
@@ -102,7 +103,7 @@ func createExplorerBlock(block *model.Block) *ExplorerBlock {
 	var payloadJSON []byte
 	basicBlock, isBasic := block.BasicBlock()
 	if isBasic {
-		payloadJSON, err = deps.Protocol.APIForVersion(iotaBlk.ProtocolVersion).JSONEncode(basicBlock.Payload)
+		payloadJSON, err = lo.PanicOnErr(deps.Protocol.APIForVersion(iotaBlk.ProtocolVersion)).JSONEncode(basicBlock.Payload)
 		if err != nil {
 			return nil
 		}
@@ -127,13 +128,13 @@ func createExplorerBlock(block *model.Block) *ExplorerBlock {
 		}(),
 		Payload:      payloadJSON,
 		CommitmentID: iotaBlk.SlotCommitmentID.ToHex(),
-		//TODO: remove from explorer or add link to a separate route
-		//Commitment: CommitmentResponse{
+		// TODO: remove from explorer or add link to a separate route
+		// Commitment: CommitmentResponse{
 		//	Index:            uint64(iotaBlk.SlotCommitmentID.Index()),
 		//	PrevID:           iotaBlk.SlotCommitment.PrevID.ToHex(),
 		//	RootsID:          iotaBlk.SlotCommitment.RootsID.ToHex(),
 		//	CumulativeWeight: iotaBlk.SlotCommitment.CumulativeWeight,
-		//},
+		// },
 		LatestConfirmedSlot: uint64(iotaBlk.LatestFinalizedSlot),
 	}
 

--- a/components/dashboard/type.go
+++ b/components/dashboard/type.go
@@ -125,7 +125,7 @@ type ExplorerBlock struct {
 	// NetworkID is the network ID of the block that attaches to.
 	NetworkID iotago.NetworkID `json:"networkID"`
 	// ProtocolVersion is the protocol that proccess the block.
-	ProtocolVersion byte `json:"protocolVersion"`
+	ProtocolVersion iotago.Version `json:"protocolVersion"`
 	// SolidificationTimestamp is the timestamp of the block.
 	SolidificationTimestamp int64 `json:"solidificationTimestamp"`
 	// The time when this block was issued

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1.0.20230706083020-ef6c3248369d
 	github.com/iotaledger/hive.go/stringify v0.0.0-20230706083020-ef6c3248369d
 	github.com/iotaledger/inx-app v1.0.0-rc.3.0.20230630104742-e00321c8e813
-	github.com/iotaledger/iota.go/v4 v4.0.0-20230712101749-e877453129b0
+	github.com/iotaledger/iota.go/v4 v4.0.0-20230712172022-22fba04771d0
 	github.com/labstack/echo/v4 v4.10.2
 	github.com/libp2p/go-libp2p v0.28.1
 	github.com/multiformats/go-multiaddr v0.9.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/iotaledger/hive.go/app v0.0.0-20230706083020-ef6c3248369d
 	github.com/iotaledger/hive.go/autopeering v0.0.0-20230706083020-ef6c3248369d
 	github.com/iotaledger/hive.go/constraints v0.0.0-20230706083020-ef6c3248369d
-	github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230706083020-ef6c3248369d
+	github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230711121610-7d024f7b5eb5
 	github.com/iotaledger/hive.go/crypto v0.0.0-20230706083020-ef6c3248369d
 	github.com/iotaledger/hive.go/ds v0.0.0-20230706083020-ef6c3248369d
 	github.com/iotaledger/hive.go/ierrors v0.0.0-20230706083020-ef6c3248369d
@@ -22,7 +22,7 @@ require (
 	github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1.0.20230706083020-ef6c3248369d
 	github.com/iotaledger/hive.go/stringify v0.0.0-20230706083020-ef6c3248369d
 	github.com/iotaledger/inx-app v1.0.0-rc.3.0.20230630104742-e00321c8e813
-	github.com/iotaledger/iota.go/v4 v4.0.0-20230710120021-31d7d74cb077
+	github.com/iotaledger/iota.go/v4 v4.0.0-20230712101749-e877453129b0
 	github.com/labstack/echo/v4 v4.10.2
 	github.com/libp2p/go-libp2p v0.28.1
 	github.com/multiformats/go-multiaddr v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,8 @@ github.com/iotaledger/hive.go/constraints v0.0.0-20230706083020-ef6c3248369d h1:
 github.com/iotaledger/hive.go/constraints v0.0.0-20230706083020-ef6c3248369d/go.mod h1:bvXXc6quBdERMMKnirr2+iQU4WnTz4KDbdHcusW9Ats=
 github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230706083020-ef6c3248369d h1:VBOXzrVDRjx+yYYSD5G38x9IdlJLfPADoo2svQVuXZM=
 github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230706083020-ef6c3248369d/go.mod h1:ALcO+4r6FMfENrMQ+jZZfHX7vDHQ42XLI8y7dt/IKxc=
+github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230711121610-7d024f7b5eb5 h1:K4dWLTZwURU7xVF5uePUk0oDViBDQrsdZ7ZHBCrTYOs=
+github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230711121610-7d024f7b5eb5/go.mod h1:ALcO+4r6FMfENrMQ+jZZfHX7vDHQ42XLI8y7dt/IKxc=
 github.com/iotaledger/hive.go/crypto v0.0.0-20230706083020-ef6c3248369d h1:6VVi5LZGAIXYFzb+/k3G6+T6dNkLi2beD0O6CccxdLg=
 github.com/iotaledger/hive.go/crypto v0.0.0-20230706083020-ef6c3248369d/go.mod h1:kkIoyWWDol9XTEuNy0wtUYQWx+Eb0Ak9XP8SS3g1/J8=
 github.com/iotaledger/hive.go/ds v0.0.0-20230706083020-ef6c3248369d h1:gcFTX8tNE5IGELuMnxD3sQYxerhLiZHQ1Zn0fTvbwRM=
@@ -274,6 +276,8 @@ github.com/iotaledger/inx-app v1.0.0-rc.3.0.20230630104742-e00321c8e813 h1:6/Ge9
 github.com/iotaledger/inx-app v1.0.0-rc.3.0.20230630104742-e00321c8e813/go.mod h1:d/oNTc8b3qnmdf70GzNFfAha9gZjXGYqImNxMGU96Eo=
 github.com/iotaledger/iota.go/v4 v4.0.0-20230710120021-31d7d74cb077 h1:ZFwWVojtc5s1xwvCcjeLQSuoerJTSdFHnydB3vUts44=
 github.com/iotaledger/iota.go/v4 v4.0.0-20230710120021-31d7d74cb077/go.mod h1:NC48ByX78DwdkGj5YjqI2ADHAY+S2idcIRZaEuWDe1Q=
+github.com/iotaledger/iota.go/v4 v4.0.0-20230712101749-e877453129b0 h1:Tr7dChXQBMV7VVW5FUpG8zn9Ex+v/1CtFFNRmGobtIc=
+github.com/iotaledger/iota.go/v4 v4.0.0-20230712101749-e877453129b0/go.mod h1:4IyZrkfhL9sXNKCwx/j8lhQOYo0tE2XIVla5WVP37LE=
 github.com/ipfs/go-cid v0.4.1 h1:A/T3qGvxi4kpKWWcPC/PgbvDA2bjVLO7n4UeVwnbs/s=
 github.com/ipfs/go-cid v0.4.1/go.mod h1:uQHwDeX4c6CtyrFwdqyhpNcxVewur1M7l7fNU7LKwZk=
 github.com/ipfs/go-detect-race v0.0.1 h1:qX/xay2W3E4Q1U7d9lNs1sU9nvguX0a7319XbyQ6cOk=

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,6 @@ github.com/iotaledger/hive.go/autopeering v0.0.0-20230706083020-ef6c3248369d h1:
 github.com/iotaledger/hive.go/autopeering v0.0.0-20230706083020-ef6c3248369d/go.mod h1:UMlY0WBdBfahTLoFxEvziZQAZqUTVYd3mDigdC0r2RA=
 github.com/iotaledger/hive.go/constraints v0.0.0-20230706083020-ef6c3248369d h1:AE8Zcydin/3DRzT7A58ESmU60g8EtpnoFZ9MVkeMWgQ=
 github.com/iotaledger/hive.go/constraints v0.0.0-20230706083020-ef6c3248369d/go.mod h1:bvXXc6quBdERMMKnirr2+iQU4WnTz4KDbdHcusW9Ats=
-github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230706083020-ef6c3248369d h1:VBOXzrVDRjx+yYYSD5G38x9IdlJLfPADoo2svQVuXZM=
-github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230706083020-ef6c3248369d/go.mod h1:ALcO+4r6FMfENrMQ+jZZfHX7vDHQ42XLI8y7dt/IKxc=
 github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230711121610-7d024f7b5eb5 h1:K4dWLTZwURU7xVF5uePUk0oDViBDQrsdZ7ZHBCrTYOs=
 github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230711121610-7d024f7b5eb5/go.mod h1:ALcO+4r6FMfENrMQ+jZZfHX7vDHQ42XLI8y7dt/IKxc=
 github.com/iotaledger/hive.go/crypto v0.0.0-20230706083020-ef6c3248369d h1:6VVi5LZGAIXYFzb+/k3G6+T6dNkLi2beD0O6CccxdLg=
@@ -274,10 +272,8 @@ github.com/iotaledger/hive.go/stringify v0.0.0-20230706083020-ef6c3248369d h1:l1
 github.com/iotaledger/hive.go/stringify v0.0.0-20230706083020-ef6c3248369d/go.mod h1:l/F3cA/+67QdNj+sohv2v4HhmsdOcWScoA+sVYoAE4c=
 github.com/iotaledger/inx-app v1.0.0-rc.3.0.20230630104742-e00321c8e813 h1:6/Ge9Gv9ZxEDn6f7dKAVEC30mkZBzE9SSktd/dyob6s=
 github.com/iotaledger/inx-app v1.0.0-rc.3.0.20230630104742-e00321c8e813/go.mod h1:d/oNTc8b3qnmdf70GzNFfAha9gZjXGYqImNxMGU96Eo=
-github.com/iotaledger/iota.go/v4 v4.0.0-20230710120021-31d7d74cb077 h1:ZFwWVojtc5s1xwvCcjeLQSuoerJTSdFHnydB3vUts44=
-github.com/iotaledger/iota.go/v4 v4.0.0-20230710120021-31d7d74cb077/go.mod h1:NC48ByX78DwdkGj5YjqI2ADHAY+S2idcIRZaEuWDe1Q=
-github.com/iotaledger/iota.go/v4 v4.0.0-20230712101749-e877453129b0 h1:Tr7dChXQBMV7VVW5FUpG8zn9Ex+v/1CtFFNRmGobtIc=
-github.com/iotaledger/iota.go/v4 v4.0.0-20230712101749-e877453129b0/go.mod h1:4IyZrkfhL9sXNKCwx/j8lhQOYo0tE2XIVla5WVP37LE=
+github.com/iotaledger/iota.go/v4 v4.0.0-20230712172022-22fba04771d0 h1:/iR++QN0IrMecLikaxwhgpIGldaUncwgooz59pOXNtA=
+github.com/iotaledger/iota.go/v4 v4.0.0-20230712172022-22fba04771d0/go.mod h1:4IyZrkfhL9sXNKCwx/j8lhQOYo0tE2XIVla5WVP37LE=
 github.com/ipfs/go-cid v0.4.1 h1:A/T3qGvxi4kpKWWcPC/PgbvDA2bjVLO7n4UeVwnbs/s=
 github.com/ipfs/go-cid v0.4.1/go.mod h1:uQHwDeX4c6CtyrFwdqyhpNcxVewur1M7l7fNU7LKwZk=
 github.com/ipfs/go-detect-race v0.0.1 h1:qX/xay2W3E4Q1U7d9lNs1sU9nvguX0a7319XbyQ6cOk=

--- a/pkg/blockfactory/block_params.go
+++ b/pkg/blockfactory/block_params.go
@@ -14,7 +14,7 @@ type BlockParams struct {
 	payload               iotago.Payload
 	latestFinalizedSlot   *iotago.SlotIndex
 	issuingTime           *time.Time
-	protocolVersion       *byte
+	protocolVersion       *iotago.Version
 	issuer                Account
 	proofOfWorkDifficulty *float64
 }

--- a/pkg/blockfactory/blockissuer.go
+++ b/pkg/blockfactory/blockissuer.go
@@ -94,7 +94,11 @@ func (i *BlockIssuer) CreateBlock(ctx context.Context, opts ...options.Option[Bl
 
 	var api iotago.API
 	if blockParams.protocolVersion != nil {
-		api = i.protocol.APIForVersion(*blockParams.protocolVersion)
+		var err error
+		api, err = i.protocol.APIForVersion(*blockParams.protocolVersion)
+		if err != nil {
+			return nil, ierrors.Wrapf(err, "error getting api for version %d", *blockParams.protocolVersion)
+		}
 	} else {
 		api = i.protocol.MainEngineInstance().Storage.Settings().LatestAPI()
 	}

--- a/pkg/core/api/api_provider.go
+++ b/pkg/core/api/api_provider.go
@@ -3,7 +3,7 @@ package api
 import iotago "github.com/iotaledger/iota.go/v4"
 
 type Provider interface {
-	APIForVersion(iotago.Version) iotago.API
+	APIForVersion(iotago.Version) (iotago.API, error)
 	APIForSlot(iotago.SlotIndex) iotago.API
 	APIForEpoch(iotago.EpochIndex) iotago.API
 

--- a/pkg/core/api/static_api_provider.go
+++ b/pkg/core/api/static_api_provider.go
@@ -12,8 +12,8 @@ type staticAPIProvider struct {
 	api iotago.API
 }
 
-func (t *staticAPIProvider) APIForVersion(iotago.Version) iotago.API {
-	return t.api
+func (t *staticAPIProvider) APIForVersion(iotago.Version) (iotago.API, error) {
+	return t.api, nil
 }
 
 func (t *staticAPIProvider) APIForSlot(iotago.SlotIndex) iotago.API {

--- a/pkg/model/block.go
+++ b/pkg/model/block.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 
+	"github.com/iotaledger/hive.go/ierrors"
 	"github.com/iotaledger/hive.go/serializer/v2/serix"
 	"github.com/iotaledger/iota-core/pkg/core/api"
 	iotago "github.com/iotaledger/iota.go/v4"
@@ -53,19 +54,24 @@ func BlockFromIDAndBytes(blockID iotago.BlockID, data []byte, api iotago.API, op
 }
 
 func BlockFromBytes(data []byte, apiProvider api.Provider, opts ...serix.Option) (*Block, error) {
-	api := apiProvider.APIForVersion(data[0])
+	version, _, err := iotago.VersionFromBytes(data)
+	if err != nil {
+		return nil, ierrors.Wrap(err, "failed to determine version")
+	}
+
+	apiForVersion := apiProvider.APIForVersion(version)
 
 	iotaBlock := new(iotago.ProtocolBlock)
-	if _, err := api.Decode(data, iotaBlock, opts...); err != nil {
+	if _, err := apiForVersion.Decode(data, iotaBlock, opts...); err != nil {
 		return nil, err
 	}
 
-	blockID, err := iotaBlock.ID(api)
+	blockID, err := iotaBlock.ID(apiForVersion)
 	if err != nil {
 		return nil, err
 	}
 
-	return newBlock(blockID, iotaBlock, data, api)
+	return newBlock(blockID, iotaBlock, data, apiForVersion)
 }
 
 func (blk *Block) ID() iotago.BlockID {

--- a/pkg/model/block.go
+++ b/pkg/model/block.go
@@ -59,7 +59,10 @@ func BlockFromBytes(data []byte, apiProvider api.Provider, opts ...serix.Option)
 		return nil, ierrors.Wrap(err, "failed to determine version")
 	}
 
-	apiForVersion := apiProvider.APIForVersion(version)
+	apiForVersion, err := apiProvider.APIForVersion(version)
+	if err != nil {
+		return nil, ierrors.Wrapf(err, "failed to get API for version %d", version)
+	}
 
 	iotaBlock := new(iotago.ProtocolBlock)
 	if _, err := apiForVersion.Decode(data, iotaBlock, opts...); err != nil {

--- a/pkg/model/commitment.go
+++ b/pkg/model/commitment.go
@@ -54,7 +54,10 @@ func CommitmentFromBytes(data []byte, apiProvider api.Provider, opts ...serix.Op
 		return nil, ierrors.Wrap(err, "failed to determine version")
 	}
 
-	apiForVersion := apiProvider.APIForVersion(version)
+	apiForVersion, err := apiProvider.APIForVersion(version)
+	if err != nil {
+		return nil, ierrors.Wrapf(err, "failed to get API for version %d", version)
+	}
 
 	iotaCommitment := new(iotago.Commitment)
 	if _, err := apiForVersion.Decode(data, iotaCommitment, opts...); err != nil {

--- a/pkg/network/protocols/core/protocol.go
+++ b/pkg/network/protocols/core/protocol.go
@@ -197,7 +197,8 @@ func (p *Protocol) onAttestations(commitmentBytes []byte, attestationsBytes []by
 	}
 
 	var attestations []*iotago.Attestation
-	if _, err := p.apiProvider.APIForVersion(commitmentBytes[0]).Decode(attestationsBytes, &attestations, serix.WithValidation()); err != nil {
+	// TODO: there could be multiple versions of attestations in the same packet
+	if _, err := p.apiProvider.APIForVersion(iotago.Version(commitmentBytes[0])).Decode(attestationsBytes, &attestations, serix.WithValidation()); err != nil {
 		p.Events.Error.Trigger(ierrors.Wrap(err, "failed to deserialize attestations"), id)
 
 		return

--- a/pkg/network/protocols/core/protocol.go
+++ b/pkg/network/protocols/core/protocol.go
@@ -78,7 +78,8 @@ func (p *Protocol) SendSlotCommitment(cm *model.Commitment, to ...network.PeerID
 func (p *Protocol) SendAttestations(cm *model.Commitment, attestations []*iotago.Attestation, merkleProof *merklehasher.Proof[iotago.Identifier], to ...network.PeerID) {
 	var iotagoAPI iotago.API
 	if len(attestations) > 0 {
-		iotagoAPI = p.apiProvider.APIForVersion(attestations[0].ProtocolVersion)
+		// TODO: there are multiple attestations potentially spanning multiple epochs/versions, we need to use the correct API for each one
+		iotagoAPI = lo.PanicOnErr(p.apiProvider.APIForVersion(attestations[0].ProtocolVersion))
 	} else {
 		iotagoAPI = p.apiProvider.APIForSlot(cm.Index()) // we need an api to serialize empty slices as well
 	}
@@ -198,7 +199,7 @@ func (p *Protocol) onAttestations(commitmentBytes []byte, attestationsBytes []by
 
 	var attestations []*iotago.Attestation
 	// TODO: there could be multiple versions of attestations in the same packet
-	if _, err := p.apiProvider.APIForVersion(iotago.Version(commitmentBytes[0])).Decode(attestationsBytes, &attestations, serix.WithValidation()); err != nil {
+	if _, err := lo.PanicOnErr(p.apiProvider.APIForVersion(iotago.Version(commitmentBytes[0]))).Decode(attestationsBytes, &attestations, serix.WithValidation()); err != nil {
 		p.Events.Error.Trigger(ierrors.Wrap(err, "failed to deserialize attestations"), id)
 
 		return

--- a/pkg/protocol/commitment_verifier.go
+++ b/pkg/protocol/commitment_verifier.go
@@ -30,8 +30,13 @@ func (c *CommitmentVerifier) verifyCommitment(prevCommitment, commitment *model.
 			return c.engine.APIForVersion(attestation.ProtocolVersion).Encode(attestation)
 		},
 		func(bytes []byte) (*iotago.Attestation, int, error) {
+			version, _, err := iotago.VersionFromBytes(bytes)
+			if err != nil {
+				return nil, 0, ierrors.Wrap(err, "failed to determine version")
+			}
+
 			a := new(iotago.Attestation)
-			n, err := c.engine.APIForVersion(bytes[0]).Decode(bytes, a)
+			n, err := c.engine.APIForVersion(version).Decode(bytes, a)
 
 			return a, n, err
 		},

--- a/pkg/protocol/engine/engine.go
+++ b/pkg/protocol/engine/engine.go
@@ -262,7 +262,7 @@ func (e *Engine) APIForEpoch(epoch iotago.EpochIndex) iotago.API {
 	return e.Storage.Settings().APIForEpoch(epoch)
 }
 
-func (e *Engine) APIForVersion(version iotago.Version) iotago.API {
+func (e *Engine) APIForVersion(version iotago.Version) (iotago.API, error) {
 	return e.Storage.Settings().APIForVersion(version)
 }
 

--- a/pkg/protocol/engine/filter/blockfilter/filter_test.go
+++ b/pkg/protocol/engine/filter/blockfilter/filter_test.go
@@ -43,8 +43,8 @@ func NewTestFramework(t *testing.T, api iotago.API, optsFilter ...options.Option
 	return tf
 }
 
-func (t *TestFramework) APIForVersion(iotago.Version) iotago.API {
-	return t.api
+func (t *TestFramework) APIForVersion(iotago.Version) (iotago.API, error) {
+	return t.api, nil
 }
 
 func (t *TestFramework) APIForSlot(_ iotago.SlotIndex) iotago.API {

--- a/pkg/protocol/protocol.go
+++ b/pkg/protocol/protocol.go
@@ -313,7 +313,7 @@ func (p *Protocol) LatestAPI() iotago.API {
 	return p.MainEngineInstance().LatestAPI()
 }
 
-func (p *Protocol) APIForVersion(version iotago.Version) iotago.API {
+func (p *Protocol) APIForVersion(version iotago.Version) (iotago.API, error) {
 	return p.MainEngineInstance().APIForVersion(version)
 }
 

--- a/pkg/storage/permanent/commitments.go
+++ b/pkg/storage/permanent/commitments.go
@@ -1,7 +1,6 @@
 package permanent
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/iotaledger/hive.go/ierrors"
@@ -40,7 +39,6 @@ func (c *Commitments) Store(commitment *model.Commitment) error {
 }
 
 func (c *Commitments) Load(index iotago.SlotIndex) (commitment *model.Commitment, err error) {
-	fmt.Println("Commitments.Load", index)
 	return c.store.Get(index)
 }
 

--- a/pkg/storage/permanent/commitments.go
+++ b/pkg/storage/permanent/commitments.go
@@ -1,6 +1,7 @@
 package permanent
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/iotaledger/hive.go/ierrors"
@@ -18,7 +19,6 @@ type Commitments struct {
 }
 
 func NewCommitments(store kvstore.KVStore, apiProvider api.Provider) *Commitments {
-
 	return &Commitments{
 		apiProvider: apiProvider,
 		store: kvstore.NewTypedStore(store,
@@ -40,6 +40,7 @@ func (c *Commitments) Store(commitment *model.Commitment) error {
 }
 
 func (c *Commitments) Load(index iotago.SlotIndex) (commitment *model.Commitment, err error) {
+	fmt.Println("Commitments.Load", index)
 	return c.store.Get(index)
 }
 

--- a/pkg/storage/permanent/settings.go
+++ b/pkg/storage/permanent/settings.go
@@ -66,32 +66,59 @@ func (s *Settings) HighestSupportedProtocolVersion() iotago.Version {
 var _ api.Provider = &Settings{}
 
 func (s *Settings) LatestAPI() iotago.API {
-	return s.APIForVersion(iotago.LatestProtocolVersion())
+	// There can't be an error since we are using the latest protocol version which should always exist.
+	return lo.PanicOnErr(s.APIForVersion(iotago.LatestProtocolVersion()))
 }
 
 func (s *Settings) APIForSlot(slot iotago.SlotIndex) iotago.API {
-	return s.APIForVersion(s.VersionForSlot(slot))
+	apiForSlot, err := s.APIForVersion(s.VersionForSlot(slot))
+
+	// This means that the protocol version for the given slot is known but not supported yet. This could only happen after an upgrade
+	// has been scheduled at a future epoch but the node software not yet upgraded to support it AND while misusing the API.
+	// Before a slot can be determined APIForVersion must be called on said object which will already return an error that
+	// the protocol version is not supported.
+	if err != nil {
+		panic(err)
+	}
+
+	return apiForSlot
 }
 
 func (s *Settings) APIForEpoch(epoch iotago.EpochIndex) iotago.API {
-	return s.APIForVersion(s.VersionForEpoch(epoch))
+	apiForEpoch, err := s.APIForVersion(s.VersionForEpoch(epoch))
+
+	// This means that the protocol version for the given epoch is known but not supported yet. This could only happen after an upgrade
+	// has been scheduled at a future epoch but the node software not yet upgraded to support it AND while misusing the API.
+	// Before a slot can be determined APIForVersion must be called on said object which will already return an error that
+	// the protocol version is not supported.
+	if err != nil {
+		panic(err)
+	}
+
+	return apiForEpoch
 }
 
-func (s *Settings) APIForVersion(version iotago.Version) iotago.API {
+// APIForVersion returns the API for the given protocol version.
+// This function is safe to be called with data received from the network. It will return an error if the protocol
+// version is not supported.
+func (s *Settings) APIForVersion(version iotago.Version) (iotago.API, error) {
 	s.apiMutex.RLock()
 	if api, exists := s.apiByVersion[version]; exists {
 		s.apiMutex.RUnlock()
-		return api
+		return api, nil
 	}
 	s.apiMutex.RUnlock()
 
-	api := s.apiFromProtocolParameters(version)
+	api, err := s.apiFromProtocolParameters(version)
+	if err != nil {
+		return nil, ierrors.Wrap(err, "failed to create API from protocol parameters")
+	}
 
 	s.apiMutex.Lock()
 	s.apiByVersion[version] = api
 	s.apiMutex.Unlock()
 
-	return api
+	return api, nil
 }
 
 func (s *Settings) StoreProtocolParameters(params iotago.ProtocolParameters) error {
@@ -226,7 +253,8 @@ func (s *Settings) Export(writer io.WriteSeeker, targetCommitment *iotago.Commit
 	var commitmentBytes []byte
 	var err error
 	if targetCommitment != nil {
-		commitmentBytes, err = s.APIForVersion(targetCommitment.Version).Encode(targetCommitment)
+		// We always know the version of the target commitment, so there can be no error.
+		commitmentBytes, err = lo.PanicOnErr(s.APIForVersion(targetCommitment.Version)).Encode(targetCommitment)
 		if err != nil {
 			return ierrors.Wrap(err, "failed to encode target commitment")
 		}
@@ -394,16 +422,12 @@ func (s *Settings) String() string {
 	return builder.String()
 }
 
-func (s *Settings) latestAPI() iotago.API {
-	return s.apiForVersion(iotago.LatestProtocolVersion())
-}
-
 func (s *Settings) latestCommitment() *model.Commitment {
 	bytes, err := s.store.Get([]byte{latestCommitmentKey})
 
 	if err != nil {
 		if ierrors.Is(err, kvstore.ErrKeyNotFound) {
-			return model.NewEmptyCommitment(s.latestAPI())
+			return model.NewEmptyCommitment(s.LatestAPI())
 		}
 		panic(err)
 	}
@@ -427,32 +451,18 @@ func (s *Settings) latestFinalizedSlot() iotago.SlotIndex {
 	return i
 }
 
-func (s *Settings) apiForVersion(version iotago.Version) iotago.API {
-	if api, exists := s.apiByVersion[version]; exists {
-		return api
-	}
-
-	api := s.apiFromProtocolParameters(version)
-
-	s.apiMutex.Lock()
-	s.apiByVersion[version] = api
-	s.apiMutex.Unlock()
-
-	return api
-}
-
-func (s *Settings) apiFromProtocolParameters(version iotago.Version) iotago.API {
+func (s *Settings) apiFromProtocolParameters(version iotago.Version) (iotago.API, error) {
 	protocolParams := s.protocolParameters(version)
 	if protocolParams == nil {
-		panic(ierrors.Errorf("protocol parameters for version %d not found", version))
+		return nil, ierrors.Errorf("protocol parameters for version %d not found", version)
 	}
 
 	switch protocolParams.Version() {
 	case 3:
-		return iotago.V3API(protocolParams)
-	default:
-		panic(ierrors.Errorf("unsupported protocol version %d", protocolParams.Version()))
+		return iotago.V3API(protocolParams), nil
 	}
+
+	return nil, ierrors.Errorf("unsupported protocol version %d", protocolParams.Version())
 }
 
 func (s *Settings) protocolParameters(version iotago.Version) iotago.ProtocolParameters {

--- a/pkg/testsuite/mock/node.go
+++ b/pkg/testsuite/mock/node.go
@@ -154,7 +154,7 @@ func (n *Node) HookLogging() {
 
 	events.Network.AttestationsReceived.Hook(func(commitment *model.Commitment, attestations []*iotago.Attestation, merkleProof *merklehasher.Proof[iotago.Identifier], source network.PeerID) {
 		fmt.Printf("%s > Network.AttestationsReceived: from %s %s number of attestations: %d with merkleProof: %s - %s\n", n.Name, source, commitment.ID(), len(attestations), lo.PanicOnErr(json.Marshal(merkleProof)), lo.Map(attestations, func(a *iotago.Attestation) iotago.BlockID {
-			return lo.PanicOnErr(a.BlockID(n.Protocol.APIForVersion(a.ProtocolVersion)))
+			return lo.PanicOnErr(a.BlockID(lo.PanicOnErr(n.Protocol.APIForVersion(a.ProtocolVersion))))
 		}))
 	})
 

--- a/tools/gendoc/go.mod
+++ b/tools/gendoc/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/iotaledger/hive.go/ads v0.0.0-20230706083020-ef6c3248369d // indirect
 	github.com/iotaledger/hive.go/autopeering v0.0.0-20230706083020-ef6c3248369d // indirect
 	github.com/iotaledger/hive.go/constraints v0.0.0-20230706083020-ef6c3248369d // indirect
-	github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230706083020-ef6c3248369d // indirect
+	github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230711121610-7d024f7b5eb5 // indirect
 	github.com/iotaledger/hive.go/crypto v0.0.0-20230706083020-ef6c3248369d // indirect
 	github.com/iotaledger/hive.go/ds v0.0.0-20230706083020-ef6c3248369d // indirect
 	github.com/iotaledger/hive.go/ierrors v0.0.0-20230706083020-ef6c3248369d // indirect
@@ -63,7 +63,7 @@ require (
 	github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1.0.20230706083020-ef6c3248369d // indirect
 	github.com/iotaledger/hive.go/stringify v0.0.0-20230706083020-ef6c3248369d // indirect
 	github.com/iotaledger/inx-app v1.0.0-rc.3.0.20230630104742-e00321c8e813 // indirect
-	github.com/iotaledger/iota.go/v4 v4.0.0-20230710120021-31d7d74cb077 // indirect
+	github.com/iotaledger/iota.go/v4 v4.0.0-20230712172022-22fba04771d0 // indirect
 	github.com/ipfs/go-cid v0.4.1 // indirect
 	github.com/ipfs/go-log/v2 v2.5.1 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect

--- a/tools/gendoc/go.sum
+++ b/tools/gendoc/go.sum
@@ -252,8 +252,8 @@ github.com/iotaledger/hive.go/autopeering v0.0.0-20230706083020-ef6c3248369d h1:
 github.com/iotaledger/hive.go/autopeering v0.0.0-20230706083020-ef6c3248369d/go.mod h1:UMlY0WBdBfahTLoFxEvziZQAZqUTVYd3mDigdC0r2RA=
 github.com/iotaledger/hive.go/constraints v0.0.0-20230706083020-ef6c3248369d h1:AE8Zcydin/3DRzT7A58ESmU60g8EtpnoFZ9MVkeMWgQ=
 github.com/iotaledger/hive.go/constraints v0.0.0-20230706083020-ef6c3248369d/go.mod h1:bvXXc6quBdERMMKnirr2+iQU4WnTz4KDbdHcusW9Ats=
-github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230706083020-ef6c3248369d h1:VBOXzrVDRjx+yYYSD5G38x9IdlJLfPADoo2svQVuXZM=
-github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230706083020-ef6c3248369d/go.mod h1:ALcO+4r6FMfENrMQ+jZZfHX7vDHQ42XLI8y7dt/IKxc=
+github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230711121610-7d024f7b5eb5 h1:K4dWLTZwURU7xVF5uePUk0oDViBDQrsdZ7ZHBCrTYOs=
+github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230711121610-7d024f7b5eb5/go.mod h1:ALcO+4r6FMfENrMQ+jZZfHX7vDHQ42XLI8y7dt/IKxc=
 github.com/iotaledger/hive.go/crypto v0.0.0-20230706083020-ef6c3248369d h1:6VVi5LZGAIXYFzb+/k3G6+T6dNkLi2beD0O6CccxdLg=
 github.com/iotaledger/hive.go/crypto v0.0.0-20230706083020-ef6c3248369d/go.mod h1:kkIoyWWDol9XTEuNy0wtUYQWx+Eb0Ak9XP8SS3g1/J8=
 github.com/iotaledger/hive.go/ds v0.0.0-20230706083020-ef6c3248369d h1:gcFTX8tNE5IGELuMnxD3sQYxerhLiZHQ1Zn0fTvbwRM=
@@ -274,8 +274,8 @@ github.com/iotaledger/hive.go/stringify v0.0.0-20230706083020-ef6c3248369d h1:l1
 github.com/iotaledger/hive.go/stringify v0.0.0-20230706083020-ef6c3248369d/go.mod h1:l/F3cA/+67QdNj+sohv2v4HhmsdOcWScoA+sVYoAE4c=
 github.com/iotaledger/inx-app v1.0.0-rc.3.0.20230630104742-e00321c8e813 h1:6/Ge9Gv9ZxEDn6f7dKAVEC30mkZBzE9SSktd/dyob6s=
 github.com/iotaledger/inx-app v1.0.0-rc.3.0.20230630104742-e00321c8e813/go.mod h1:d/oNTc8b3qnmdf70GzNFfAha9gZjXGYqImNxMGU96Eo=
-github.com/iotaledger/iota.go/v4 v4.0.0-20230710120021-31d7d74cb077 h1:ZFwWVojtc5s1xwvCcjeLQSuoerJTSdFHnydB3vUts44=
-github.com/iotaledger/iota.go/v4 v4.0.0-20230710120021-31d7d74cb077/go.mod h1:NC48ByX78DwdkGj5YjqI2ADHAY+S2idcIRZaEuWDe1Q=
+github.com/iotaledger/iota.go/v4 v4.0.0-20230712172022-22fba04771d0 h1:/iR++QN0IrMecLikaxwhgpIGldaUncwgooz59pOXNtA=
+github.com/iotaledger/iota.go/v4 v4.0.0-20230712172022-22fba04771d0/go.mod h1:4IyZrkfhL9sXNKCwx/j8lhQOYo0tE2XIVla5WVP37LE=
 github.com/ipfs/go-cid v0.4.1 h1:A/T3qGvxi4kpKWWcPC/PgbvDA2bjVLO7n4UeVwnbs/s=
 github.com/ipfs/go-cid v0.4.1/go.mod h1:uQHwDeX4c6CtyrFwdqyhpNcxVewur1M7l7fNU7LKwZk=
 github.com/ipfs/go-detect-race v0.0.1 h1:qX/xay2W3E4Q1U7d9lNs1sU9nvguX0a7319XbyQ6cOk=

--- a/tools/genesis-snapshot/go.mod
+++ b/tools/genesis-snapshot/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/iotaledger/hive.go/lo v0.0.0-20230706083020-ef6c3248369d
 	github.com/iotaledger/hive.go/runtime v0.0.0-20230706083020-ef6c3248369d
 	github.com/iotaledger/iota-core v0.0.0-00010101000000-000000000000
-	github.com/iotaledger/iota.go/v4 v4.0.0-20230710120021-31d7d74cb077
+	github.com/iotaledger/iota.go/v4 v4.0.0-20230712172022-22fba04771d0
 	github.com/mr-tron/base58 v1.2.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/crypto v0.11.0
@@ -31,7 +31,7 @@ require (
 	github.com/iotaledger/grocksdb v1.7.5-0.20230220105546-5162e18885c7 // indirect
 	github.com/iotaledger/hive.go/ads v0.0.0-20230706083020-ef6c3248369d // indirect
 	github.com/iotaledger/hive.go/constraints v0.0.0-20230706083020-ef6c3248369d // indirect
-	github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230706083020-ef6c3248369d // indirect
+	github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230711121610-7d024f7b5eb5 // indirect
 	github.com/iotaledger/hive.go/crypto v0.0.0-20230706083020-ef6c3248369d // indirect
 	github.com/iotaledger/hive.go/ds v0.0.0-20230706083020-ef6c3248369d // indirect
 	github.com/iotaledger/hive.go/kvstore v0.0.0-20230706083020-ef6c3248369d // indirect

--- a/tools/genesis-snapshot/go.sum
+++ b/tools/genesis-snapshot/go.sum
@@ -37,8 +37,8 @@ github.com/iotaledger/hive.go/ads v0.0.0-20230706083020-ef6c3248369d h1:NN8dQohB
 github.com/iotaledger/hive.go/ads v0.0.0-20230706083020-ef6c3248369d/go.mod h1:LnGcXngTfpdV+JUkmUdnI6ivaq7bFfK1Gm3/wakgkbc=
 github.com/iotaledger/hive.go/constraints v0.0.0-20230706083020-ef6c3248369d h1:AE8Zcydin/3DRzT7A58ESmU60g8EtpnoFZ9MVkeMWgQ=
 github.com/iotaledger/hive.go/constraints v0.0.0-20230706083020-ef6c3248369d/go.mod h1:bvXXc6quBdERMMKnirr2+iQU4WnTz4KDbdHcusW9Ats=
-github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230706083020-ef6c3248369d h1:VBOXzrVDRjx+yYYSD5G38x9IdlJLfPADoo2svQVuXZM=
-github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230706083020-ef6c3248369d/go.mod h1:ALcO+4r6FMfENrMQ+jZZfHX7vDHQ42XLI8y7dt/IKxc=
+github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230711121610-7d024f7b5eb5 h1:K4dWLTZwURU7xVF5uePUk0oDViBDQrsdZ7ZHBCrTYOs=
+github.com/iotaledger/hive.go/core v1.0.0-rc.3.0.20230711121610-7d024f7b5eb5/go.mod h1:ALcO+4r6FMfENrMQ+jZZfHX7vDHQ42XLI8y7dt/IKxc=
 github.com/iotaledger/hive.go/crypto v0.0.0-20230706083020-ef6c3248369d h1:6VVi5LZGAIXYFzb+/k3G6+T6dNkLi2beD0O6CccxdLg=
 github.com/iotaledger/hive.go/crypto v0.0.0-20230706083020-ef6c3248369d/go.mod h1:kkIoyWWDol9XTEuNy0wtUYQWx+Eb0Ak9XP8SS3g1/J8=
 github.com/iotaledger/hive.go/ds v0.0.0-20230706083020-ef6c3248369d h1:gcFTX8tNE5IGELuMnxD3sQYxerhLiZHQ1Zn0fTvbwRM=
@@ -55,8 +55,8 @@ github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1.0.20230706083020-ef6c324
 github.com/iotaledger/hive.go/serializer/v2 v2.0.0-rc.1.0.20230706083020-ef6c3248369d/go.mod h1:2dzHxEpppULFjMRn0iyuQW81sLUuJ0Y/9zCHsRuLUvI=
 github.com/iotaledger/hive.go/stringify v0.0.0-20230706083020-ef6c3248369d h1:l1kGmeSD7dvARG4vBOYLoYKX1nN9GMzZbqVP0vT1lo0=
 github.com/iotaledger/hive.go/stringify v0.0.0-20230706083020-ef6c3248369d/go.mod h1:l/F3cA/+67QdNj+sohv2v4HhmsdOcWScoA+sVYoAE4c=
-github.com/iotaledger/iota.go/v4 v4.0.0-20230710120021-31d7d74cb077 h1:ZFwWVojtc5s1xwvCcjeLQSuoerJTSdFHnydB3vUts44=
-github.com/iotaledger/iota.go/v4 v4.0.0-20230710120021-31d7d74cb077/go.mod h1:NC48ByX78DwdkGj5YjqI2ADHAY+S2idcIRZaEuWDe1Q=
+github.com/iotaledger/iota.go/v4 v4.0.0-20230712172022-22fba04771d0 h1:/iR++QN0IrMecLikaxwhgpIGldaUncwgooz59pOXNtA=
+github.com/iotaledger/iota.go/v4 v4.0.0-20230712172022-22fba04771d0/go.mod h1:4IyZrkfhL9sXNKCwx/j8lhQOYo0tE2XIVla5WVP37LE=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=


### PR DESCRIPTION
Depends on https://github.com/iotaledger/iota.go/pull/453. After it is merged `go.mod` should be updated to latest commit.