### PR TITLE
Adjust block issuer key type.

### DIFF
--- a/pkg/protocol/engine/accounts/accountsledger/manager.go
+++ b/pkg/protocol/engine/accounts/accountsledger/manager.go
@@ -2,7 +2,6 @@ package accountsledger
 
 import (
 	"github.com/iotaledger/hive.go/ads"
-	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"github.com/iotaledger/hive.go/ds"
 	"github.com/iotaledger/hive.go/ds/shrinkingmap"
 	"github.com/iotaledger/hive.go/ierrors"
@@ -213,7 +212,7 @@ func (m *Manager) AddAccount(output *utxoledger.Output) error {
 			//  but we shouldn't simply cast the iota value to credits here.
 			accounts.WithCredits(accounts.NewBlockIssuanceCredits(iotago.BlockIssuanceCredits(accountOutput.Amount), m.latestCommittedSlot)),
 			accounts.WithOutputID(output.OutputID()),
-			accounts.WithPubKeys(ed25519.NativeToPublicKeys(accountOutput.FeatureSet().BlockIssuer().BlockIssuerKeys)...),
+			accounts.WithPubKeys(accountOutput.FeatureSet().BlockIssuer().BlockIssuerKeys...),
 		)...,
 	)
 

--- a/pkg/protocol/engine/ledger/ledger/ledger.go
+++ b/pkg/protocol/engine/ledger/ledger/ledger.go
@@ -1,14 +1,12 @@
 package ledger
 
 import (
-	cryptoed25519 "crypto/ed25519"
 	"io"
 
 	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"github.com/iotaledger/hive.go/ds"
 	"github.com/iotaledger/hive.go/ierrors"
 	"github.com/iotaledger/hive.go/kvstore"
-	"github.com/iotaledger/hive.go/lo"
 	"github.com/iotaledger/hive.go/runtime/event"
 	"github.com/iotaledger/hive.go/runtime/module"
 	"github.com/iotaledger/iota-core/pkg/core/api"
@@ -420,7 +418,7 @@ func (l *Ledger) prepareAccountDiffs(accountDiffs map[iotago.AccountID]*prunable
 		// have some values from the allotment, so no need to set them explicitly.
 		accountDiff.NewOutputID = createdOutput.OutputID()
 		accountDiff.PreviousOutputID = iotago.EmptyOutputID
-		accountDiff.PubKeysAdded = lo.Map(createdOutput.Output().FeatureSet().BlockIssuer().BlockIssuerKeys, func(pk cryptoed25519.PublicKey) ed25519.PublicKey { return ed25519.PublicKey(pk) })
+		accountDiff.PubKeysAdded = createdOutput.Output().FeatureSet().BlockIssuer().BlockIssuerKeys
 
 		if stakingFeature := createdOutput.Output().FeatureSet().Staking(); stakingFeature != nil {
 			accountDiff.ValidatorStakeChange = int64(stakingFeature.StakedAmount)

--- a/pkg/protocol/snapshotcreator/options.go
+++ b/pkg/protocol/snapshotcreator/options.go
@@ -1,8 +1,7 @@
 package snapshotcreator
 
 import (
-	"crypto/ed25519"
-
+	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"github.com/iotaledger/hive.go/runtime/module"
 	"github.com/iotaledger/hive.go/runtime/options"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine"

--- a/pkg/protocol/snapshotcreator/snapshotcreator.go
+++ b/pkg/protocol/snapshotcreator/snapshotcreator.go
@@ -1,11 +1,11 @@
 package snapshotcreator
 
 import (
-	"crypto/ed25519"
 	"os"
 
 	"golang.org/x/crypto/blake2b"
 
+	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"github.com/iotaledger/hive.go/ierrors"
 	"github.com/iotaledger/hive.go/lo"
 	"github.com/iotaledger/hive.go/runtime/options"
@@ -71,7 +71,7 @@ func CreateSnapshot(opts ...options.Option[Options]) error {
 	for _, accountData := range opt.Accounts {
 		// Only add genesis validators if an account has both - StakedAmount and StakingEndEpoch - specified.
 		if accountData.StakedAmount > 0 && accountData.StakingEpochEnd > 0 {
-			accounts.Set(blake2b.Sum256(accountData.IssuerKey), &account.Pool{
+			accounts.Set(blake2b.Sum256(accountData.IssuerKey[:]), &account.Pool{
 				PoolStake:      accountData.StakedAmount,
 				ValidatorStake: accountData.StakedAmount,
 				FixedCost:      accountData.FixedCost,

--- a/pkg/tests/accounts_test.go
+++ b/pkg/tests/accounts_test.go
@@ -19,7 +19,7 @@ import (
 
 // TODO: implement tests for staking and delegation transitions
 func Test_TransitionAccount(t *testing.T) {
-	oldGenesisOutputKey := utils.RandPubKey().ToEd25519()
+	oldGenesisOutputKey := utils.RandPubKey()
 	ts := testsuite.NewTestSuite(t, testsuite.WithAccounts(snapshotcreator.AccountDetails{
 		// Nil address will be replaced with the address generated from genesis seed.
 		// A single key may unlock multiple accounts; that's why it can't be used as a source for AccountID derivation.
@@ -51,14 +51,14 @@ func Test_TransitionAccount(t *testing.T) {
 		// TODO: why do we use the deposit here as credits?
 		Credits:  accounts.NewBlockIssuanceCredits(iotago.BlockIssuanceCredits(testsuite.MinIssuerAccountDeposit*3), 0),
 		OutputID: genesisAccount.OutputID(),
-		PubKeys:  ds.NewSet(ed25519.PublicKey(oldGenesisOutputKey)),
+		PubKeys:  ds.NewSet(oldGenesisOutputKey),
 	}, ts.Nodes()...)
 
 	// MODIFY EXISTING GENESIS ACCOUNT AND PREPARE SOME BASIC OUTPUTS
 
 	newGenesisOutputKey := utils.RandPubKey()
 	{
-		accountInput, accountOutputs, accountWallets := ts.TransactionFramework.TransitionAccount("Genesis:1", testsuite.AddBlockIssuerKey(newGenesisOutputKey[:]), testsuite.WithBlockIssuerExpirySlot(1))
+		accountInput, accountOutputs, accountWallets := ts.TransactionFramework.TransitionAccount("Genesis:1", testsuite.AddBlockIssuerKey(newGenesisOutputKey), testsuite.WithBlockIssuerExpirySlot(1))
 		consumedInputs, equalOutputs, equalWallets := ts.TransactionFramework.CreateBasicOutputsEqually(5, "Genesis:0")
 
 		tx1 := lo.PanicOnErr(ts.TransactionFramework.CreateTransactionWithOptions("TX1", append(accountWallets, equalWallets...),
@@ -108,7 +108,7 @@ func Test_TransitionAccount(t *testing.T) {
 				&iotago.GovernorAddressUnlockCondition{Address: ts.TransactionFramework.DefaultAddress()},
 			}),
 			testsuite.WithBlockIssuerFeature(&iotago.BlockIssuerFeature{
-				BlockIssuerKeys: iotago.BlockIssuerKeys{newAccountBlockIssuerKey[:]},
+				BlockIssuerKeys: iotago.BlockIssuerKeys{newAccountBlockIssuerKey},
 			}),
 			testsuite.WithStakingFeature(&iotago.StakingFeature{
 				StakedAmount: 10000,
@@ -223,7 +223,7 @@ func Test_TransitionAccount(t *testing.T) {
 			ValidatorStakeChange:  0,
 			StakeEndEpochChange:   0,
 			FixedCostChange:       0,
-			DelegationStakeChange: 1914280,
+			DelegationStakeChange: 1914080,
 		}, false, ts.Nodes()...)
 
 		ts.AssertAccountData(&accounts.AccountData{

--- a/pkg/testsuite/testsuite.go
+++ b/pkg/testsuite/testsuite.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/blake2b"
 
+	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"github.com/iotaledger/hive.go/ds/orderedmap"
 	"github.com/iotaledger/hive.go/ds/shrinkingmap"
 	"github.com/iotaledger/hive.go/lo"
@@ -31,7 +32,7 @@ import (
 )
 
 const MinIssuerAccountDeposit = iotago.BaseToken(84400)
-const MinValidatorAccountDeposit = iotago.BaseToken(87700)
+const MinValidatorAccountDeposit = iotago.BaseToken(88200)
 
 type TestSuite struct {
 	Testing     *testing.T
@@ -380,7 +381,7 @@ func (t *TestSuite) addNodeToPartition(name string, partition string, validator 
 			Address:   iotago.Ed25519AddressFromPubKey(node.PubKey),
 			Amount:    deposit,
 			Mana:      iotago.Mana(deposit),
-			IssuerKey: node.PubKey,
+			IssuerKey: ed25519.PublicKey(node.PubKey),
 		}
 		if validator {
 			accountDetails.StakedAmount = accountDetails.Amount
@@ -428,7 +429,7 @@ func (t *TestSuite) Run(nodesOptions ...map[string][]options.Option[protocol.Pro
 			}
 
 			if accountDetails.AccountID.Empty() {
-				accountDetails.AccountID = blake2b.Sum256(accountDetails.IssuerKey)
+				accountDetails.AccountID = blake2b.Sum256(accountDetails.IssuerKey[:])
 			}
 
 			return accountDetails

--- a/pkg/testsuite/transactions_framework.go
+++ b/pkg/testsuite/transactions_framework.go
@@ -1,14 +1,11 @@
 package testsuite
 
 import (
-	"bytes"
-	"crypto/ed25519"
 	"encoding/binary"
 	"fmt"
 	"time"
 
-	"golang.org/x/exp/slices"
-
+	"github.com/iotaledger/hive.go/crypto/ed25519"
 	"github.com/iotaledger/hive.go/ierrors"
 	"github.com/iotaledger/hive.go/lo"
 	"github.com/iotaledger/hive.go/runtime/options"
@@ -382,9 +379,7 @@ func AddBlockIssuerKey(key ed25519.PublicKey) options.Option[iotago.AccountOutpu
 		}
 		blockIssuer.BlockIssuerKeys = append(blockIssuer.BlockIssuerKeys, key)
 
-		slices.SortFunc(blockIssuer.BlockIssuerKeys, func(a, b ed25519.PublicKey) bool {
-			return bytes.Compare(a, b) < 0
-		})
+		blockIssuer.BlockIssuerKeys.Sort()
 	}
 }
 


### PR DESCRIPTION
This PR adjusts block issuer key type to be in line with recent iota.go changes in https://github.com/iotaledger/iota.go/pull/462