### PR TITLE
Downgrade `quic-go/qtls-go1-20` to `v2.2.0`

### DIFF
--- a/tools/gendoc/go.mod
+++ b/tools/gendoc/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/iotaledger/hive.go/stringify v0.0.0-20230721122326-34450325011f // indirect
 	github.com/iotaledger/inx-app v1.0.0-rc.3.0.20230726094056-e4fe59ff68a6 // indirect
 	github.com/iotaledger/inx/go v1.0.0-rc.2.0.20230726065442-90d758432bb7 // indirect
-	github.com/iotaledger/iota.go/v4 v4.0.0-20230726093907-2e7cfcdc28b6 // indirect
+	github.com/iotaledger/iota.go/v4 v4.0.0-20230726110608-b668253c96e1 // indirect
 	github.com/ipfs/go-cid v0.4.1 // indirect
 	github.com/ipfs/go-log/v2 v2.5.1 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
@@ -127,8 +127,9 @@ require (
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.0 // indirect
 	github.com/quic-go/qpack v0.4.0 // indirect
-	github.com/quic-go/qtls-go1-20 v0.3.0 // indirect
-	github.com/quic-go/quic-go v0.37.0 // indirect
+	github.com/quic-go/qtls-go1-19 v0.3.2 // indirect
+	github.com/quic-go/qtls-go1-20 v0.2.2 // indirect
+	github.com/quic-go/quic-go v0.36.2 // indirect
 	github.com/quic-go/webtransport-go v0.5.3 // indirect
 	github.com/raulk/go-watchdog v1.3.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect

--- a/tools/gendoc/go.sum
+++ b/tools/gendoc/go.sum
@@ -290,8 +290,8 @@ github.com/iotaledger/inx-app v1.0.0-rc.3.0.20230726094056-e4fe59ff68a6 h1:+5tDX
 github.com/iotaledger/inx-app v1.0.0-rc.3.0.20230726094056-e4fe59ff68a6/go.mod h1:pDdKl2b5wx+VEwcIntbQvThu5Tpq0mUcg5KuQKjimP4=
 github.com/iotaledger/inx/go v1.0.0-rc.2.0.20230726065442-90d758432bb7 h1:zPisRu9k7E7yZlx3lPqZESZk9D5E7qNAUIsqIVCISKs=
 github.com/iotaledger/inx/go v1.0.0-rc.2.0.20230726065442-90d758432bb7/go.mod h1:z8tFR7vLD11nSmwBgxNQpM2t12OxUagQ+Dtz/4Q6Sm8=
-github.com/iotaledger/iota.go/v4 v4.0.0-20230726093907-2e7cfcdc28b6 h1:2ZzO1cY/zBC0x7OizXE0yR+BlD0Q5Bal3oWZjfLMxUw=
-github.com/iotaledger/iota.go/v4 v4.0.0-20230726093907-2e7cfcdc28b6/go.mod h1:4IyZrkfhL9sXNKCwx/j8lhQOYo0tE2XIVla5WVP37LE=
+github.com/iotaledger/iota.go/v4 v4.0.0-20230726110608-b668253c96e1 h1:NtoXdqKK4hyipHY0EAwRoj58eS9SoYusp/cp+4lhLzQ=
+github.com/iotaledger/iota.go/v4 v4.0.0-20230726110608-b668253c96e1/go.mod h1:4IyZrkfhL9sXNKCwx/j8lhQOYo0tE2XIVla5WVP37LE=
 github.com/ipfs/go-cid v0.4.1 h1:A/T3qGvxi4kpKWWcPC/PgbvDA2bjVLO7n4UeVwnbs/s=
 github.com/ipfs/go-cid v0.4.1/go.mod h1:uQHwDeX4c6CtyrFwdqyhpNcxVewur1M7l7fNU7LKwZk=
 github.com/ipfs/go-detect-race v0.0.1 h1:qX/xay2W3E4Q1U7d9lNs1sU9nvguX0a7319XbyQ6cOk=
@@ -513,10 +513,12 @@ github.com/prometheus/procfs v0.11.0 h1:5EAgkfkMl659uZPbe9AS2N68a7Cc1TJbPEuGzFuR
 github.com/prometheus/procfs v0.11.0/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/quic-go/qpack v0.4.0 h1:Cr9BXA1sQS2SmDUWjSofMPNKmvF6IiIfDRmgU0w1ZCo=
 github.com/quic-go/qpack v0.4.0/go.mod h1:UZVnYIfi5GRk+zI9UMaCPsmZ2xKJP7XBUvVyT1Knj9A=
-github.com/quic-go/qtls-go1-20 v0.3.0 h1:NrCXmDl8BddZwO67vlvEpBTwT89bJfKYygxv4HQvuDk=
-github.com/quic-go/qtls-go1-20 v0.3.0/go.mod h1:X9Nh97ZL80Z+bX/gUXMbipO6OxdiDi58b/fMC9mAL+k=
-github.com/quic-go/quic-go v0.37.0 h1:wf/Ym2yeWi98oQn4ahiBSqdnaXVxNQGj2oBQFgiVChc=
-github.com/quic-go/quic-go v0.37.0/go.mod h1:XtCUOCALTTWbPyd0IxFfHf6h0sEMubRFvEYHl3QxKw8=
+github.com/quic-go/qtls-go1-19 v0.3.2 h1:tFxjCFcTQzK+oMxG6Zcvp4Dq8dx4yD3dDiIiyc86Z5U=
+github.com/quic-go/qtls-go1-19 v0.3.2/go.mod h1:ySOI96ew8lnoKPtSqx2BlI5wCpUVPT05RMAlajtnyOI=
+github.com/quic-go/qtls-go1-20 v0.2.2 h1:WLOPx6OY/hxtTxKV1Zrq20FtXtDEkeY00CGQm8GEa3E=
+github.com/quic-go/qtls-go1-20 v0.2.2/go.mod h1:JKtK6mjbAVcUTN/9jZpvLbGxvdWIKS8uT7EiStoU1SM=
+github.com/quic-go/quic-go v0.36.2 h1:ZX/UNQ4gvpCv2RmwdbA6lrRjF6EBm5yZ7TMoT4NQVrA=
+github.com/quic-go/quic-go v0.36.2/go.mod h1:zPetvwDlILVxt15n3hr3Gf/I3mDf7LpLKPhR4Ez0AZQ=
 github.com/quic-go/webtransport-go v0.5.3 h1:5XMlzemqB4qmOlgIus5zB45AcZ2kCgCy2EptUrfOPWU=
 github.com/quic-go/webtransport-go v0.5.3/go.mod h1:OhmmgJIzTTqXK5xvtuX0oBpLV2GkLWNDA+UeTGJXErU=
 github.com/raulk/go-watchdog v1.3.0 h1:oUmdlHxdkXRJlwfG0O9omj8ukerm8MEQavSiDTEtBsk=


### PR DESCRIPTION
Fixes a known issue with libp2p https://github.com/libp2p/go-libp2p/releases/tag/v0.29.0. 

The changes are the result of running `go get github.com/quic-go/qtls-go1-20@v0.2.2` in `tools/gendoc`.