### PR TITLE
Use serix version of API responses 

### DIFF
--- a/components/restapi/core/accounts.go
+++ b/components/restapi/core/accounts.go
@@ -51,7 +51,7 @@ func staking() (*apimodels.AccountStakingListResponse, error) {
 
 	for _, accountData := range activeValidators {
 		resp.Stakers = append(resp.Stakers, apimodels.ValidatorResponse{
-			AccountID:                      accountData.ID.ToHex(),
+			AccountID:                      accountData.ID,
 			PoolStake:                      accountData.ValidatorStake + accountData.DelegationStake,
 			ValidatorStake:                 accountData.ValidatorStake,
 			FixedCost:                      accountData.FixedCost,
@@ -79,7 +79,7 @@ func stakingByAccountID(c echo.Context) (*apimodels.ValidatorResponse, error) {
 	}
 
 	return &apimodels.ValidatorResponse{
-		AccountID:                      accountID.ToHex(),
+		AccountID:                      accountID,
 		PoolStake:                      accountData.ValidatorStake + accountData.DelegationStake,
 		ValidatorStake:                 accountData.ValidatorStake,
 		StakingEpochEnd:                accountData.StakeEndEpoch,
@@ -162,7 +162,7 @@ func selectedCommittee(c echo.Context) *apimodels.CommitteeResponse {
 	committee := make([]apimodels.CommitteeMemberResponse, 0, seatedAccounts.Accounts().Size())
 	seatedAccounts.Accounts().ForEach(func(accountID iotago.AccountID, seat *account.Pool) bool {
 		committee = append(committee, apimodels.CommitteeMemberResponse{
-			AccountID:      accountID.ToHex(),
+			AccountID:      accountID,
 			PoolStake:      seat.PoolStake,
 			ValidatorStake: seat.ValidatorStake,
 			FixedCost:      seat.FixedCost,

--- a/components/restapi/core/blocks.go
+++ b/components/restapi/core/blocks.go
@@ -55,9 +55,9 @@ func blockIssuance(_ echo.Context) (*apimodels.IssuanceBlockHeaderResponse, erro
 	}
 
 	resp := &apimodels.IssuanceBlockHeaderResponse{
-		StrongParents:       references[iotago.StrongParentType].ToHex(),
-		WeakParents:         references[iotago.WeakParentType].ToHex(),
-		ShallowLikeParents:  references[iotago.ShallowLikeParentType].ToHex(),
+		StrongParents:       references[iotago.StrongParentType],
+		WeakParents:         references[iotago.WeakParentType],
+		ShallowLikeParents:  references[iotago.ShallowLikeParentType],
 		LatestFinalizedSlot: deps.Protocol.SyncManager.LatestFinalizedSlot(),
 		Commitment:          *slotCommitment.Commitment(),
 	}
@@ -125,6 +125,6 @@ func sendBlock(c echo.Context) (*apimodels.BlockCreatedResponse, error) {
 	}
 
 	return &apimodels.BlockCreatedResponse{
-		BlockID: blockID.ToHex(),
+		BlockID: blockID,
 	}, nil
 }

--- a/components/restapi/core/component.go
+++ b/components/restapi/core/component.go
@@ -153,7 +153,7 @@ func configure() error {
 			return err
 		}
 
-		return httpserver.JSONResponse(c, http.StatusOK, resp)
+		return responseByHeader(c, resp)
 	})
 
 	routeGroup.GET(RouteBlock, func(c echo.Context) error {
@@ -172,7 +172,7 @@ func configure() error {
 			return err
 		}
 
-		return httpserver.JSONResponse(c, http.StatusOK, resp)
+		return responseByHeader(c, resp)
 	}, checkNodeSynced())
 
 	routeGroup.POST(RouteBlocks, func(c echo.Context) error {
@@ -180,7 +180,7 @@ func configure() error {
 		if err != nil {
 			return err
 		}
-		c.Response().Header().Set(echo.HeaderLocation, resp.BlockID)
+		c.Response().Header().Set(echo.HeaderLocation, resp.BlockID.ToHex())
 
 		return httpserver.JSONResponse(c, http.StatusCreated, resp)
 	}, checkNodeSynced(), checkUpcomingUnsupportedProtocolVersion())
@@ -219,7 +219,7 @@ func configure() error {
 			return err
 		}
 
-		return httpserver.JSONResponse(c, http.StatusOK, resp)
+		return responseByHeader(c, resp)
 	})
 
 	routeGroup.GET(RouteCommitmentByIndex, func(c echo.Context) error {
@@ -247,7 +247,7 @@ func configure() error {
 			return err
 		}
 
-		return httpserver.JSONResponse(c, http.StatusOK, resp)
+		return responseByHeader(c, resp)
 	})
 
 	routeGroup.GET(RouteOutput, func(c echo.Context) error {
@@ -265,7 +265,7 @@ func configure() error {
 			return err
 		}
 
-		return httpserver.JSONResponse(c, http.StatusOK, resp)
+		return responseByHeader(c, resp)
 	})
 
 	routeGroup.GET(RouteTransactionsIncludedBlock, func(c echo.Context) error {
@@ -283,7 +283,7 @@ func configure() error {
 			return err
 		}
 
-		return httpserver.JSONResponse(c, http.StatusOK, resp)
+		return responseByHeader(c, resp)
 	}, checkNodeSynced())
 
 	routeGroup.GET(RouteCongestion, func(c echo.Context) error {
@@ -292,7 +292,7 @@ func configure() error {
 			return err
 		}
 
-		return httpserver.JSONResponse(c, http.StatusOK, resp)
+		return responseByHeader(c, resp)
 	}, checkNodeSynced())
 
 	routeGroup.GET(RouteStaking, func(c echo.Context) error {
@@ -301,7 +301,7 @@ func configure() error {
 			return err
 		}
 
-		return httpserver.JSONResponse(c, http.StatusOK, resp)
+		return responseByHeader(c, resp)
 	}, checkNodeSynced())
 
 	routeGroup.GET(RouteStakingAccount, func(c echo.Context) error {
@@ -310,7 +310,7 @@ func configure() error {
 			return err
 		}
 
-		return httpserver.JSONResponse(c, http.StatusOK, resp)
+		return responseByHeader(c, resp)
 	}, checkNodeSynced())
 
 	routeGroup.GET(RouteRewards, func(c echo.Context) error {
@@ -319,13 +319,13 @@ func configure() error {
 			return err
 		}
 
-		return httpserver.JSONResponse(c, http.StatusOK, resp)
+		return responseByHeader(c, resp)
 	}, checkNodeSynced())
 
 	routeGroup.GET(RouteCommittee, func(c echo.Context) error {
 		resp := selectedCommittee(c)
 
-		return httpserver.JSONResponse(c, http.StatusOK, resp)
+		return responseByHeader(c, resp)
 	}, checkNodeSynced())
 
 	return nil

--- a/components/restapi/core/node.go
+++ b/components/restapi/core/node.go
@@ -1,8 +1,6 @@
 package core
 
 import (
-	"encoding/json"
-
 	"github.com/iotaledger/iota.go/v4/nodeclient/apimodels"
 )
 
@@ -12,12 +10,6 @@ func info() (*apimodels.InfoResponse, error) {
 	syncStatus := deps.Protocol.SyncManager.SyncStatus()
 	metrics := deps.MetricsTracker.NodeMetrics()
 	protoParams := deps.Protocol.CurrentAPI().ProtocolParameters()
-
-	protoParamsBytes, err := deps.Protocol.CurrentAPI().JSONEncode(protoParams)
-	if err != nil {
-		return nil, err
-	}
-	protoParamsJSONRaw := json.RawMessage(protoParamsBytes)
 
 	return &apimodels.InfoResponse{
 		Name:    deps.AppInfo.Name,
@@ -41,7 +33,16 @@ func info() (*apimodels.InfoResponse, error) {
 			ConfirmationRate:         metrics.ConfirmedRate,
 		},
 		SupportedProtocolVersions: deps.Protocol.SupportedVersions(),
-		ProtocolParameters:        &protoParamsJSONRaw,
-		Features:                  features,
+		ProtocolParameters:        protoParams,
+		// TODO: fill in base token
+		BaseToken: &apimodels.InfoResBaseToken{
+			Name:            "IOTA",
+			TickerSymbol:    "todo",
+			Unit:            "todo",
+			Subunit:         "todo",
+			Decimals:        10,
+			UseMetricPrefix: false,
+		},
+		Features: features,
 	}, nil
 }

--- a/components/restapi/core/utxo.go
+++ b/components/restapi/core/utxo.go
@@ -45,11 +45,11 @@ func newOutputMetadataResponse(output *utxoledger.Output) (*apimodels.OutputMeta
 	latestCommitment := deps.Protocol.SyncManager.LatestCommitment()
 
 	resp := &apimodels.OutputMetadataResponse{
-		BlockID:            output.BlockID().ToHex(),
-		TransactionID:      output.OutputID().TransactionID().ToHex(),
+		BlockID:            output.BlockID(),
+		TransactionID:      output.OutputID().TransactionID(),
 		OutputIndex:        output.OutputID().Index(),
 		IsSpent:            false,
-		LatestCommitmentID: latestCommitment.ID().ToHex(),
+		LatestCommitmentID: latestCommitment.ID(),
 	}
 
 	includedSlotIndex := output.SlotBooked()
@@ -58,7 +58,7 @@ func newOutputMetadataResponse(output *utxoledger.Output) (*apimodels.OutputMeta
 		if err != nil {
 			return nil, err
 		}
-		resp.IncludedCommitmentID = includedCommitment.ID().ToHex()
+		resp.IncludedCommitmentID = includedCommitment.ID()
 	}
 
 	return resp, nil
@@ -68,12 +68,12 @@ func newSpentMetadataResponse(spent *utxoledger.Spent) (*apimodels.OutputMetadat
 	latestCommitment := deps.Protocol.SyncManager.LatestCommitment()
 
 	resp := &apimodels.OutputMetadataResponse{
-		BlockID:            spent.BlockID().ToHex(),
-		TransactionID:      spent.OutputID().TransactionID().ToHex(),
+		BlockID:            spent.BlockID(),
+		TransactionID:      spent.OutputID().TransactionID(),
 		OutputIndex:        spent.OutputID().Index(),
 		IsSpent:            true,
-		TransactionIDSpent: spent.TransactionIDSpent().ToHex(),
-		LatestCommitmentID: latestCommitment.ID().ToHex(),
+		TransactionIDSpent: spent.TransactionIDSpent(),
+		LatestCommitmentID: latestCommitment.ID(),
 	}
 
 	includedSlotIndex := spent.Output().SlotBooked()
@@ -82,7 +82,7 @@ func newSpentMetadataResponse(spent *utxoledger.Spent) (*apimodels.OutputMetadat
 		if err != nil {
 			return nil, err
 		}
-		resp.IncludedCommitmentID = includedCommitment.ID().ToHex()
+		resp.IncludedCommitmentID = includedCommitment.ID()
 	}
 
 	spentSlotIndex := spent.SlotIndexSpent()
@@ -91,7 +91,7 @@ func newSpentMetadataResponse(spent *utxoledger.Spent) (*apimodels.OutputMetadat
 		if err != nil {
 			return nil, err
 		}
-		resp.CommitmentIDSpent = spentCommitment.ID().ToHex()
+		resp.CommitmentIDSpent = spentCommitment.ID()
 	}
 
 	return resp, nil

--- a/components/restapi/params.go
+++ b/components/restapi/params.go
@@ -41,8 +41,12 @@ var ParamsRestAPI = &ParametersRestAPI{
 		"/api/core/v3/transactions*",
 		"/api/core/v3/commitments*",
 		"/api/core/v3/outputs*",
+		"/api/core/v3/accounts*",
+		"/api/core/v3/staking*",
+		"/api/core/v3/rewards*",
+		"/api/core/v3/committee",
 		"/api/debug/v2/*",
-		"/api/indexer/v1/*",
+		"/api/indexer/v2/*",
 	},
 	ProtectedRoutes: []string{
 		"/api/*",

--- a/pkg/retainer/block_metadata.go
+++ b/pkg/retainer/block_metadata.go
@@ -15,7 +15,7 @@ type BlockMetadata struct {
 
 func (b *BlockMetadata) BlockMetadataResponse() *apimodels.BlockMetadataResponse {
 	response := &apimodels.BlockMetadataResponse{
-		BlockID:            b.BlockID.ToHex(),
+		BlockID:            b.BlockID,
 		BlockState:         b.BlockState.String(),
 		BlockFailureReason: b.BlockFailureReason,
 		TxFailureReason:    b.TxFailureReason,

--- a/pkg/retainer/retainer/retainer.go
+++ b/pkg/retainer/retainer/retainer.go
@@ -129,6 +129,9 @@ func (r *Retainer) Shutdown() {
 
 func (r *Retainer) BlockMetadata(blockID iotago.BlockID) (*retainer.BlockMetadata, error) {
 	blockStatus, blockFailureReason := r.blockStatus(blockID)
+	if blockStatus == apimodels.BlockStateUnknown {
+		return nil, ierrors.Errorf("block %s not found", blockID.ToHex())
+	}
 
 	// we do not expose accepted flag
 	if blockStatus == apimodels.BlockStateAccepted {

--- a/tools/evil-spammer/wallet/connector.go
+++ b/tools/evil-spammer/wallet/connector.go
@@ -205,7 +205,7 @@ func NewWebClient(url string, opts ...options.Option[WebClient]) *WebClient {
 
 		info, err := tmpClient.Info(context.Background())
 		if err == nil {
-			_ = tmpAPI.JSONDecode(*info.ProtocolParameters, &w.optsProtocolParams)
+			w.optsProtocolParams = info.ProtocolParameters
 		}
 
 		w.serixAPI = iotago.V3API(w.optsProtocolParams)


### PR DESCRIPTION
* Adapt changes in [iota.go PR 470](https://github.com/iotaledger/iota.go/pull/470)
* Handle `BlockStateUnknown` in retainer
* Expose account related apis