### PR TITLE
Properly filter for validation blocks in the blockgadget, attestations, upgrade orchestrator and sybilprotection

### DIFF
--- a/pkg/protocol/engine/attestation/attestations.go
+++ b/pkg/protocol/engine/attestation/attestations.go
@@ -17,7 +17,7 @@ type Attestations interface {
 	// GetMap returns the attestations that are included in the commitment of the given slot as ads.Map.
 	// If attestationCommitmentOffset=3 and commitment is 10, then the returned attestations are blocks from 7 to 10 that commit to at least 7.
 	GetMap(index iotago.SlotIndex) (attestations ads.Map[iotago.AccountID, *iotago.Attestation], err error)
-	AddAttestationFromBlock(block *blocks.Block)
+	AddAttestationFromValidationBlock(block *blocks.Block)
 	Commit(index iotago.SlotIndex) (newCW uint64, attestationsRoot iotago.Identifier, err error)
 
 	Import(reader io.ReadSeeker) (err error)

--- a/pkg/protocol/engine/attestation/slotattestation/manager.go
+++ b/pkg/protocol/engine/attestation/slotattestation/manager.go
@@ -154,8 +154,13 @@ func (m *Manager) GetMap(index iotago.SlotIndex) (ads.Map[iotago.AccountID, *iot
 	return m.attestationsForSlot(cutoffIndex)
 }
 
-// AddAttestationFromBlock adds an attestation from a block to the future attestations (beyond the attestation window).
-func (m *Manager) AddAttestationFromBlock(block *blocks.Block) {
+// AddAttestationFromValidationBlock adds an attestation from a block to the future attestations (beyond the attestation window).
+func (m *Manager) AddAttestationFromValidationBlock(block *blocks.Block) {
+	// Only track validator blocks.
+	if _, isValidationBlock := block.ValidationBlock(); !isValidationBlock {
+		return
+	}
+
 	// Only track attestations of active committee members.
 	if _, exists := m.committeeFunc(block.ID().Index()).GetSeat(block.ProtocolBlock().IssuerID); !exists {
 		return

--- a/pkg/protocol/engine/attestation/slotattestation/testframework_test.go
+++ b/pkg/protocol/engine/attestation/slotattestation/testframework_test.go
@@ -101,7 +101,7 @@ func (t *TestFramework) AddFutureAttestation(issuerAlias string, attestationAlia
 	issuer := t.issuer(issuerAlias)
 	issuingTime := tpkg.TestAPI.TimeProvider().SlotStartTime(blockSlot).Add(time.Duration(t.uniqueCounter.Add(1))).UTC()
 
-	block, err := builder.NewBasicBlockBuilder(tpkg.TestAPI).
+	block, err := builder.NewValidationBlockBuilder(tpkg.TestAPI).
 		IssuingTime(issuingTime).
 		SlotCommitmentID(iotago.NewCommitment(tpkg.TestAPI.Version(), attestedSlot, iotago.CommitmentID{}, iotago.Identifier{}, 0).MustID()).
 		Sign(issuer.accountID, issuer.priv).
@@ -115,7 +115,7 @@ func (t *TestFramework) AddFutureAttestation(issuerAlias string, attestationAlia
 	modelBlock, err := model.BlockFromBlock(block, tpkg.TestAPI)
 	require.NoError(t.test, err)
 
-	t.Instance.AddAttestationFromBlock(blocks.NewBlock(modelBlock))
+	t.Instance.AddAttestationFromValidationBlock(blocks.NewBlock(modelBlock))
 }
 
 func (t *TestFramework) blockIDFromAttestation(att *iotago.Attestation) iotago.BlockID {

--- a/pkg/protocol/engine/consensus/blockgadget/thresholdblockgadget/acceptance_ratification.go
+++ b/pkg/protocol/engine/consensus/blockgadget/thresholdblockgadget/acceptance_ratification.go
@@ -8,11 +8,9 @@ import (
 )
 
 func (g *Gadget) trackAcceptanceRatifierWeight(votingBlock *blocks.Block) {
-	ratifier := votingBlock.ProtocolBlock().IssuerID
-
 	// Only track ratifier weight for issuers that are part of the committee.
-	seat, exists := g.seatManager.Committee(votingBlock.ID().Index()).GetSeat(ratifier)
-	if !exists {
+	seat, isValid := g.isCommitteeValidationBlock(votingBlock)
+	if !isValid {
 		return
 	}
 

--- a/pkg/protocol/engine/consensus/blockgadget/thresholdblockgadget/confirmation_ratification.go
+++ b/pkg/protocol/engine/consensus/blockgadget/thresholdblockgadget/confirmation_ratification.go
@@ -6,14 +6,13 @@ import (
 )
 
 func (g *Gadget) trackConfirmationRatifierWeight(votingBlock *blocks.Block) {
-	ratifier := votingBlock.ProtocolBlock().IssuerID
-	ratifierBlockIndex := votingBlock.ID().Index()
-
 	// Only track ratifier weight for issuers that are part of the committee.
-	seat, exists := g.seatManager.Committee(votingBlock.ID().Index()).GetSeat(ratifier)
-	if !exists {
+	seat, isValid := g.isCommitteeValidationBlock(votingBlock)
+	if !isValid {
 		return
 	}
+
+	ratifierBlockIndex := votingBlock.ID().Index()
 
 	var toConfirm []*blocks.Block
 

--- a/pkg/protocol/engine/consensus/blockgadget/thresholdblockgadget/gadget.go
+++ b/pkg/protocol/engine/consensus/blockgadget/thresholdblockgadget/gadget.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iotaledger/hive.go/runtime/event"
 	"github.com/iotaledger/hive.go/runtime/module"
 	"github.com/iotaledger/hive.go/runtime/options"
+	"github.com/iotaledger/iota-core/pkg/core/account"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/blocks"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/consensus/blockgadget"
@@ -89,6 +90,15 @@ func (g *Gadget) propagate(initialBlockIDs iotago.BlockIDs, evaluateFunc func(bl
 
 		walk.PushAll(block.Parents()...)
 	}
+}
+
+func (g *Gadget) isCommitteeValidationBlock(block *blocks.Block) (seat account.SeatIndex, isValid bool) {
+	if _, isValidationBlock := block.ValidationBlock(); isValidationBlock {
+		return 0, false
+	}
+
+	// Only accept blocks for issuers that are part of the committee.
+	return g.seatManager.Committee(block.ID().Index()).GetSeat(block.ProtocolBlock().IssuerID)
 }
 
 func anyChildInSet(block *blocks.Block, set ds.Set[iotago.BlockID]) bool {

--- a/pkg/protocol/engine/consensus/blockgadget/thresholdblockgadget/witness_weight.go
+++ b/pkg/protocol/engine/consensus/blockgadget/thresholdblockgadget/witness_weight.go
@@ -8,11 +8,9 @@ import (
 )
 
 func (g *Gadget) TrackWitnessWeight(votingBlock *blocks.Block) {
-	witness := votingBlock.ProtocolBlock().IssuerID
-
 	// Only track witness weight for issuers that are part of the committee.
-	seat, exists := g.seatManager.Committee(votingBlock.ID().Index()).GetSeat(witness)
-	if !exists {
+	seat, isValid := g.isCommitteeValidationBlock(votingBlock)
+	if !isValid {
 		return
 	}
 

--- a/pkg/protocol/engine/engine.go
+++ b/pkg/protocol/engine/engine.go
@@ -399,9 +399,9 @@ func (e *Engine) acceptanceHandler() {
 	wp := e.Workers.CreatePool("BlockAccepted", 1)
 
 	e.Events.BlockGadget.BlockAccepted.Hook(func(block *blocks.Block) {
-		e.Ledger.BlockAccepted(block)
-		e.SybilProtection.BlockAccepted(block)
-		e.UpgradeOrchestrator.TrackBlock(block)
+		e.Ledger.TrackBlock(block)
+		e.SybilProtection.TrackValidationBlock(block)
+		e.UpgradeOrchestrator.TrackValidationBlock(block)
 
 		e.Events.AcceptedBlockProcessed.Trigger(block)
 	}, event.WithWorkerPool(wp))

--- a/pkg/protocol/engine/ledger/ledger.go
+++ b/pkg/protocol/engine/ledger/ledger.go
@@ -39,7 +39,7 @@ type Ledger interface {
 
 	Import(reader io.ReadSeeker) error
 	Export(writer io.WriteSeeker, targetIndex iotago.SlotIndex) error
-	BlockAccepted(block *blocks.Block)
+	TrackBlock(block *blocks.Block)
 
 	module.Interface
 }

--- a/pkg/protocol/engine/ledger/ledger/ledger.go
+++ b/pkg/protocol/engine/ledger/ledger/ledger.go
@@ -207,7 +207,7 @@ func (l *Ledger) AddGenesisUnspentOutput(unspentOutput *utxoledger.Output) error
 	return l.utxoLedger.AddGenesisUnspentOutput(unspentOutput)
 }
 
-func (l *Ledger) BlockAccepted(block *blocks.Block) {
+func (l *Ledger) TrackBlock(block *blocks.Block) {
 	l.accountsLedger.TrackBlock(block)
 
 	if _, hasTransaction := block.Transaction(); hasTransaction {

--- a/pkg/protocol/engine/notarization/slotnotarization/manager.go
+++ b/pkg/protocol/engine/notarization/slotnotarization/manager.go
@@ -116,7 +116,7 @@ func (m *Manager) notarizeAcceptedBlock(block *blocks.Block) (err error) {
 		return ierrors.Wrap(err, "failed to add accepted block to slot mutations")
 	}
 
-	m.attestation.AddAttestationFromBlock(block)
+	m.attestation.AddAttestationFromValidationBlock(block)
 
 	return
 }

--- a/pkg/protocol/engine/upgrade/orchestrator.go
+++ b/pkg/protocol/engine/upgrade/orchestrator.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Orchestrator interface {
-	TrackBlock(block *blocks.Block)
+	TrackValidationBlock(block *blocks.Block)
 	Commit(slot iotago.SlotIndex) (protocolParametersAndVersionsHash iotago.Identifier, err error)
 
 	Import(reader io.ReadSeeker) error

--- a/pkg/protocol/engine/upgrade/signalingupgradeorchestrator/orchestrator.go
+++ b/pkg/protocol/engine/upgrade/signalingupgradeorchestrator/orchestrator.go
@@ -137,19 +137,19 @@ func (o *Orchestrator) Shutdown() {
 	o.TriggerStopped()
 }
 
-func (o *Orchestrator) TrackBlock(block *blocks.Block) {
-	committee := o.seatManager.Committee(block.ID().Index())
-	seat, exists := committee.GetSeat(block.ProtocolBlock().IssuerID)
-	if !exists {
-		return
-	}
-
+func (o *Orchestrator) TrackValidationBlock(block *blocks.Block) {
 	// Not a validation block.
 	validationBlock, isValidationBlock := block.ValidationBlock()
 	if !isValidationBlock {
 		return
 	}
 	newSignaledBlock := prunable.NewSignaledBlock(block.ID(), block.ProtocolBlock(), validationBlock)
+
+	committee := o.seatManager.Committee(block.ID().Index())
+	seat, exists := committee.GetSeat(block.ProtocolBlock().IssuerID)
+	if !exists {
+		return
+	}
 
 	// Do not track any version that we already know about. This includes past, current and future versions that are already
 	// successfully signaled and scheduled to start in a future epoch.

--- a/pkg/protocol/sybilprotection/sybilprotection.go
+++ b/pkg/protocol/sybilprotection/sybilprotection.go
@@ -11,7 +11,7 @@ import (
 )
 
 type SybilProtection interface {
-	BlockAccepted(block *blocks.Block)
+	TrackValidationBlock(block *blocks.Block)
 	EligibleValidators(epoch iotago.EpochIndex) (accounts.AccountsData, error)
 	ValidatorReward(validatorID iotago.AccountID, stakeAmount iotago.BaseToken, epochStart, epochEnd iotago.EpochIndex) (validatorReward iotago.Mana, err error)
 	DelegatorReward(validatorID iotago.AccountID, delegatedAmount iotago.BaseToken, epochStart, epochEnd iotago.EpochIndex) (delegatorsReward iotago.Mana, err error)

--- a/pkg/protocol/sybilprotection/sybilprotectionv1/performance/performance.go
+++ b/pkg/protocol/sybilprotection/sybilprotectionv1/performance/performance.go
@@ -56,15 +56,17 @@ func (t *Tracker) RegisterCommittee(epoch iotago.EpochIndex, committee *account.
 	return t.committeeStore.Set(epoch, committee)
 }
 
-func (t *Tracker) BlockAccepted(block *blocks.Block) {
+func (t *Tracker) TrackValidationBlock(block *blocks.Block) {
+	validatorBlock, isValidationBlock := block.ValidationBlock()
+	if !isValidationBlock {
+		return
+	}
+
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
 	t.performanceFactorsMutex.Lock()
 	defer t.performanceFactorsMutex.Unlock()
-
-	// TODO: check if this block is a validator block
-	// TODO: include wannabe validator performance in the snapshot
 
 	performanceFactors := t.performanceFactorsFunc(block.ID().Index())
 	pf, err := performanceFactors.Load(block.ProtocolBlock().IssuerID)
@@ -72,6 +74,9 @@ func (t *Tracker) BlockAccepted(block *blocks.Block) {
 		// TODO replace panic with errors in the future, like triggering an error event
 		panic(ierrors.Errorf("failed to load performance factor for account %s", block.ProtocolBlock().IssuerID))
 	}
+
+	// TODO: store highest supported version per validator?
+	_ = validatorBlock.HighestSupportedVersion
 
 	err = performanceFactors.Store(block.ProtocolBlock().IssuerID, pf+1)
 	if err != nil {

--- a/pkg/protocol/sybilprotection/sybilprotectionv1/performance/testsuite_test.go
+++ b/pkg/protocol/sybilprotection/sybilprotectionv1/performance/testsuite_test.go
@@ -136,7 +136,7 @@ func (t *TestSuite) applyPerformanceFactor(accountID iotago.AccountID, epochInde
 			block := tpkg.RandBasicBlockWithIssuerAndBurnedMana(accountID, 10)
 			block.IssuingTime = t.API.TimeProvider().SlotStartTime(slot)
 			modelBlock, err := model.BlockFromBlock(block, t.API)
-			t.Instance.BlockAccepted(blocks.NewBlock(modelBlock))
+			t.Instance.TrackValidationBlock(blocks.NewBlock(modelBlock))
 
 			require.NoError(t.T, err)
 		}

--- a/pkg/protocol/sybilprotection/sybilprotectionv1/sybilprotection.go
+++ b/pkg/protocol/sybilprotection/sybilprotectionv1/sybilprotection.go
@@ -101,8 +101,8 @@ func (o *SybilProtection) Shutdown() {
 	o.TriggerStopped()
 }
 
-func (o *SybilProtection) BlockAccepted(block *blocks.Block) {
-	o.performanceTracker.BlockAccepted(block)
+func (o *SybilProtection) TrackValidationBlock(block *blocks.Block) {
+	o.performanceTracker.TrackValidationBlock(block)
 }
 
 func (o *SybilProtection) CommitSlot(slot iotago.SlotIndex) (committeeRoot, rewardsRoot iotago.Identifier) {


### PR DESCRIPTION
I did not separate the events but renamed the functions expecting validation blocks and added checks to verify the passed block is a validation block