### PR TITLE
Randomize genesis output IDs.

### DIFF
--- a/.github/workflows/build_tools.yml
+++ b/.github/workflows/build_tools.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go 1.20
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: '1.20'
 
       - name: Print Go version
         run: go version

--- a/.github/workflows/build_tools.yml
+++ b/.github/workflows/build_tools.yml
@@ -1,0 +1,32 @@
+name: Build internal tools
+
+on:
+  pull_request:
+    paths:
+      - 'tools/evil-spammer/**'
+      - 'tools/genesis-snapshot/**'
+jobs:
+
+  build:
+    name: Import Check
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Go 1.20
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.20
+
+      - name: Print Go version
+        run: go version
+
+      - name: Build evil-spammer tool
+        working-directory: tools/evil-spammer
+        run: go mod tidy && go build .
+
+      - name: Build genesis-snapshot tool
+        working-directory: tools/genesis-snapshot
+        run: go mod tidy && go build .

--- a/pkg/protocol/snapshotcreator/snapshotcreator.go
+++ b/pkg/protocol/snapshotcreator/snapshotcreator.go
@@ -117,18 +117,17 @@ func CreateSnapshot(opts ...options.Option[Options]) error {
 	return engineInstance.WriteSnapshot(opt.FilePath)
 }
 
-func createGenesisOutput(genesisTokenAmount iotago.BaseToken, genesisSeed []byte, engineInstance *engine.Engine) (err error) {
+func createGenesisOutput(genesisTokenAmount iotago.BaseToken, genesisSeed []byte, engineInstance *engine.Engine) error {
 	if genesisTokenAmount > 0 {
 		genesisWallet := mock.NewHDWallet("genesis", genesisSeed, 0)
 		output := createOutput(genesisWallet.Address(), genesisTokenAmount)
 
-		if _, err = engineInstance.CurrentAPI().ProtocolParameters().RentStructure().CoversMinDeposit(output, genesisTokenAmount); err != nil {
+		if _, err := engineInstance.CurrentAPI().ProtocolParameters().RentStructure().CoversMinDeposit(output, genesisTokenAmount); err != nil {
 			return ierrors.Wrap(err, "min rent not covered by Genesis output with index 0")
 		}
 
 		// Genesis output is on Genesis TX index 0
-		// TODO: change genesis outputID from empty transaction id to some hash, to avoid problems when rolling back newly created accounts, whose previousOutputID is also emptyTrasactionID:0 (super edge case, but better have that covered)
-		if err := engineInstance.Ledger.AddGenesisUnspentOutput(utxoledger.CreateOutput(engineInstance, iotago.OutputIDFromTransactionIDAndIndex(iotago.TransactionID{}, 0), iotago.EmptyBlockID(), 0, 0, output)); err != nil {
+		if err := engineInstance.Ledger.AddGenesisUnspentOutput(utxoledger.CreateOutput(engineInstance, iotago.OutputIDFromTransactionIDAndIndex(iotago.IdentifierFromData([]byte("genesis")), 0), iotago.EmptyBlockID(), 0, 0, output)); err != nil {
 			return err
 		}
 	}
@@ -145,7 +144,7 @@ func createGenesisAccounts(accounts []AccountDetails, engineInstance *engine.Eng
 			return ierrors.Wrapf(err, "min rent not covered by account output with index %d", idx+1)
 		}
 
-		accountOutput := utxoledger.CreateOutput(engineInstance, iotago.OutputIDFromTransactionIDAndIndex(iotago.TransactionID{}, uint16(idx+1)), iotago.EmptyBlockID(), 0, 0, output)
+		accountOutput := utxoledger.CreateOutput(engineInstance, iotago.OutputIDFromTransactionIDAndIndex(iotago.IdentifierFromData([]byte("genesis")), uint16(idx+1)), iotago.EmptyBlockID(), 0, 0, output)
 		if err := engineInstance.Ledger.AddGenesisUnspentOutput(accountOutput); err != nil {
 			return err
 		}

--- a/pkg/protocol/snapshotcreator/snapshotcreator.go
+++ b/pkg/protocol/snapshotcreator/snapshotcreator.go
@@ -43,6 +43,8 @@ import (
 // | node1       | node1       |
 // | node2       | node2       |.
 
+var GenesisTransactionID = iotago.IdentifierFromData([]byte("genesis"))
+
 func CreateSnapshot(opts ...options.Option[Options]) error {
 	opt := NewOptions(opts...)
 
@@ -127,7 +129,7 @@ func createGenesisOutput(genesisTokenAmount iotago.BaseToken, genesisSeed []byte
 		}
 
 		// Genesis output is on Genesis TX index 0
-		if err := engineInstance.Ledger.AddGenesisUnspentOutput(utxoledger.CreateOutput(engineInstance, iotago.OutputIDFromTransactionIDAndIndex(iotago.IdentifierFromData([]byte("genesis")), 0), iotago.EmptyBlockID(), 0, 0, output)); err != nil {
+		if err := engineInstance.Ledger.AddGenesisUnspentOutput(utxoledger.CreateOutput(engineInstance, iotago.OutputIDFromTransactionIDAndIndex(GenesisTransactionID, 0), iotago.EmptyBlockID(), 0, 0, output)); err != nil {
 			return err
 		}
 	}
@@ -144,7 +146,7 @@ func createGenesisAccounts(accounts []AccountDetails, engineInstance *engine.Eng
 			return ierrors.Wrapf(err, "min rent not covered by account output with index %d", idx+1)
 		}
 
-		accountOutput := utxoledger.CreateOutput(engineInstance, iotago.OutputIDFromTransactionIDAndIndex(iotago.IdentifierFromData([]byte("genesis")), uint16(idx+1)), iotago.EmptyBlockID(), 0, 0, output)
+		accountOutput := utxoledger.CreateOutput(engineInstance, iotago.OutputIDFromTransactionIDAndIndex(GenesisTransactionID, uint16(idx+1)), iotago.EmptyBlockID(), 0, 0, output)
 		if err := engineInstance.Ledger.AddGenesisUnspentOutput(accountOutput); err != nil {
 			return err
 		}

--- a/pkg/testsuite/transactions_framework.go
+++ b/pkg/testsuite/transactions_framework.go
@@ -1,7 +1,6 @@
 package testsuite
 
 import (
-	"encoding/binary"
 	"fmt"
 	"time"
 
@@ -29,7 +28,7 @@ type TransactionFramework struct {
 
 func NewTransactionFramework(protocol *protocol.Protocol, genesisSeed []byte, accounts ...snapshotcreator.AccountDetails) *TransactionFramework {
 	// The genesis output is on index 0 of the genesis TX
-	genesisOutput, err := protocol.MainEngineInstance().Ledger.Output(iotago.OutputID{})
+	genesisOutput, err := protocol.MainEngineInstance().Ledger.Output(iotago.OutputIDFromTransactionIDAndIndex(snapshotcreator.GenesisTransactionID, 0))
 	if err != nil {
 		panic(err)
 	}
@@ -43,9 +42,8 @@ func NewTransactionFramework(protocol *protocol.Protocol, genesisSeed []byte, ac
 
 	for idx := range accounts {
 		// Genesis TX
-		outputID := iotago.OutputID{}
-		// Accounts start from index 1 of the genesis TX
-		binary.LittleEndian.PutUint16(outputID[iotago.TransactionIDLength:], uint16(idx+1))
+		outputID := iotago.OutputIDFromTransactionIDAndIndex(snapshotcreator.GenesisTransactionID, uint16(idx+1))
+
 		if tf.states[fmt.Sprintf("Genesis:%d", idx+1)], err = protocol.MainEngineInstance().Ledger.Output(outputID); err != nil {
 			panic(err)
 		}

--- a/tools/evil-spammer/basic.go
+++ b/tools/evil-spammer/basic.go
@@ -26,7 +26,7 @@ type CustomSpamParams struct {
 }
 
 func CustomSpam(params *CustomSpamParams) {
-	outputID := iotago.EmptyOutputID
+	outputID := iotago.OutputIDFromTransactionIDAndIndex(iotago.IdentifierFromData([]byte("genesis")), 0)
 	if params.config.LastFaucetUnspentOutputID != "" {
 		outputID, _ = iotago.OutputIDFromHex(params.config.LastFaucetUnspentOutputID)
 	}

--- a/tools/evil-spammer/basic.go
+++ b/tools/evil-spammer/basic.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/iotaledger/iota-core/pkg/protocol/snapshotcreator"
 	"github.com/iotaledger/iota-core/tools/evil-spammer/spammer"
 	"github.com/iotaledger/iota-core/tools/evil-spammer/wallet"
 	iotago "github.com/iotaledger/iota.go/v4"
@@ -26,7 +27,7 @@ type CustomSpamParams struct {
 }
 
 func CustomSpam(params *CustomSpamParams) {
-	outputID := iotago.OutputIDFromTransactionIDAndIndex(iotago.IdentifierFromData([]byte("genesis")), 0)
+	outputID := iotago.OutputIDFromTransactionIDAndIndex(snapshotcreator.GenesisTransactionID, 0)
 	if params.config.LastFaucetUnspentOutputID != "" {
 		outputID, _ = iotago.OutputIDFromHex(params.config.LastFaucetUnspentOutputID)
 	}

--- a/tools/evil-spammer/wallet/connector.go
+++ b/tools/evil-spammer/wallet/connector.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iotaledger/hive.go/runtime/syncutils"
 	"github.com/iotaledger/iota-core/pkg/model"
 	iotago "github.com/iotaledger/iota.go/v4"
+	"github.com/iotaledger/iota.go/v4/api"
 	"github.com/iotaledger/iota.go/v4/builder"
 	"github.com/iotaledger/iota.go/v4/nodeclient"
 	"github.com/iotaledger/iota.go/v4/nodeclient/apimodels"
@@ -175,12 +176,34 @@ type Client interface {
 	GetTransaction(txID iotago.TransactionID) (resp *iotago.Transaction, err error)
 	// GetBlockIssuance returns the latest commitment and data needed to create a new block.
 	GetBlockIssuance() (resp *apimodels.IssuanceBlockHeaderResponse, err error)
+
+	api.Provider
 }
 
 // WebClient contains a GoShimmer web API to interact with a node.
 type WebClient struct {
 	client *nodeclient.Client
 	url    string
+}
+
+func (c *WebClient) APIForVersion(version iotago.Version) (iotago.API, error) {
+	return c.client.APIForVersion(version)
+}
+
+func (c *WebClient) APIForSlot(index iotago.SlotIndex) iotago.API {
+	return c.client.APIForSlot(index)
+}
+
+func (c *WebClient) APIForEpoch(index iotago.EpochIndex) iotago.API {
+	return c.client.APIForEpoch(index)
+}
+
+func (c *WebClient) CurrentAPI() iotago.API {
+	return c.client.CurrentAPI()
+}
+
+func (c *WebClient) LatestAPI() iotago.API {
+	return c.client.LatestAPI()
 }
 
 // URL returns a client API Url.

--- a/tools/evil-spammer/wallet/evilwallet.go
+++ b/tools/evil-spammer/wallet/evilwallet.go
@@ -34,6 +34,8 @@ const (
 var (
 	defaultClientsURLs = []string{"http://localhost:8080", "http://localhost:8090"}
 
+	genesisTransactionID = iotago.IdentifierFromData([]byte("genesis"))
+
 	dockerFaucetSeed = func() []byte {
 		genesisSeed, err := base58.Decode("7R1itJx5hVuo9w9hjg5cwKFmek4HMSoBDgJZN8hKGxih")
 		if err != nil {
@@ -66,7 +68,7 @@ func NewEvilWallet(opts ...options.Option[EvilWallet]) *EvilWallet {
 		wallets:                  NewWallets(),
 		aliasManager:             NewAliasManager(),
 		optFaucetSeed:            dockerFaucetSeed(),
-		optFaucetUnspentOutputID: iotago.OutputIDFromTransactionIDAndIndex(iotago.IdentifierFromData([]byte("genesis")), 0),
+		optFaucetUnspentOutputID: iotago.OutputIDFromTransactionIDAndIndex(genesisTransactionID, 0),
 		optsClientURLs:           defaultClientsURLs,
 	}, opts, func(w *EvilWallet) {
 		connector := NewWebClients(w.optsClientURLs)
@@ -87,7 +89,7 @@ func NewEvilWallet(opts ...options.Option[EvilWallet]) *EvilWallet {
 			faucetAmount = faucetOutput.BaseTokenAmount()
 		} else {
 			// use the genesis output ID instead, if we relaunch the docker network
-			w.optFaucetUnspentOutputID = iotago.OutputIDFromTransactionIDAndIndex(iotago.IdentifierFromData([]byte("genesis")), 0)
+			w.optFaucetUnspentOutputID = iotago.OutputIDFromTransactionIDAndIndex(genesisTransactionID, 0)
 			faucetOutput = clt.GetOutput(w.optFaucetUnspentOutputID)
 			if faucetOutput != nil {
 				faucetAmount = faucetOutput.BaseTokenAmount()


### PR DESCRIPTION
Previously genesis OutputIDs were generated using empty transaction ID, which e.g. during account rollbacks or regular rollbacks could cause some problems, because when an account is created, the diff for the account contains previous OutputID which is set to empty TransactionID as well! 

In order to avoid using the same OutputID value in multiple contexts, the genesis snapshot generation tool now sets a predefined TransactionID (blake2b hash of string `genesis`) to the genesis OutputID in order to avoid conflicts.

This PR also fixes some existing compile errors with evil spammer and adds evil spammer build check to the CI to always make sure that it can compile correctly. 