### PR TITLE
Resolve ledger mempool TODOs

### DIFF
--- a/pkg/protocol/engine/ledger/ledger/vm.go
+++ b/pkg/protocol/engine/ledger/ledger/vm.go
@@ -105,7 +105,6 @@ func (l *Ledger) executeStardustVM(_ context.Context, stateTransition mempool.Tr
 	}
 	resolvedInputs.RewardsInputSet = rewardInputSet
 
-	// TODO: in which slot is this transaction?
 	api := l.apiProvider.APIForSlot(tx.Essence.CreationSlot)
 
 	vmParams := &iotagovm.Params{

--- a/pkg/protocol/engine/mempool/v1/mempool.go
+++ b/pkg/protocol/engine/mempool/v1/mempool.go
@@ -376,7 +376,7 @@ func (m *MemPool[VoteRank]) updateStateDiffs(transaction *TransactionMetadata, p
 
 	if transaction.IsAccepted() && newIndex != 0 {
 		if stateDiff, evicted := m.stateDiff(newIndex); !evicted {
-			if err := stateDiff.AddTransaction(transaction); err != nil {
+			if err := stateDiff.AddTransaction(transaction, m.errorHandler); err != nil {
 				return ierrors.Wrapf(err, "failed to add transaction to state diff, txID: %s", transaction.ID())
 			}
 		}
@@ -405,7 +405,7 @@ func (m *MemPool[VoteRank]) setupTransaction(transaction *TransactionMetadata) {
 	transaction.OnAccepted(func() {
 		if slotIndex := transaction.EarliestIncludedAttachment().Index(); slotIndex > 0 {
 			if stateDiff, evicted := m.stateDiff(slotIndex); !evicted {
-				if err := stateDiff.AddTransaction(transaction); err != nil {
+				if err := stateDiff.AddTransaction(transaction, m.errorHandler); err != nil {
 					m.errorHandler(ierrors.Wrapf(err, "failed to add transaction to state diff, txID: %s", transaction.ID()))
 				}
 			}

--- a/pkg/protocol/engine/mempool/v1/state_diff.go
+++ b/pkg/protocol/engine/mempool/v1/state_diff.go
@@ -69,7 +69,7 @@ func (s *StateDiff) updateCompactedStateChanges(transaction *TransactionMetadata
 	})
 }
 
-func (s *StateDiff) AddTransaction(transaction *TransactionMetadata) error {
+func (s *StateDiff) AddTransaction(transaction *TransactionMetadata, errorHandler func(error)) error {
 	if _, exists := s.executedTransactions.Set(transaction.ID(), transaction); !exists {
 		if err := s.mutations.Add(transaction.ID()); err != nil {
 			return ierrors.Wrapf(err, "failed to add transaction to state diff, txID: %s", transaction.ID())
@@ -78,8 +78,7 @@ func (s *StateDiff) AddTransaction(transaction *TransactionMetadata) error {
 
 		transaction.OnPending(func() {
 			if err := s.RollbackTransaction(transaction); err != nil {
-				// TODO: use error handler?
-				panic(ierrors.Wrapf(err, "failed to rollback transaction, txID: %s", transaction.ID()))
+				errorHandler(ierrors.Wrapf(err, "failed to rollback transaction, txID: %s", transaction.ID()))
 			}
 		})
 	}

--- a/pkg/tests/upgrade_signaling_test.go
+++ b/pkg/tests/upgrade_signaling_test.go
@@ -279,17 +279,4 @@ func Test_Upgrade_Signaling(t *testing.T) {
 		StakeEndEpoch:                         math.MaxUint64,
 		LatestSupportedProtocolVersionAndHash: model.VersionAndHash{Version: 5, Hash: hash2},
 	}, ts.Nodes()...)
-
-	ts.AssertAccountData(&accounts.AccountData{
-		ID:                                    ts.Node("nodeF").AccountID,
-		Credits:                               &accounts.BlockIssuanceCredits{Value: math.MaxInt64, UpdateTime: 0},
-		ExpirySlot:                            math.MaxUint64,
-		OutputID:                              iotago.OutputIDFromTransactionIDAndIndex(snapshotcreator.GenesisTransactionID, 6),
-		PubKeys:                               ds.NewSet[ed25519.PublicKey](ed25519.PublicKey(ts.Node("nodeF").PubKey)),
-		ValidatorStake:                        0,
-		DelegationStake:                       0,
-		FixedCost:                             0,
-		StakeEndEpoch:                         0,
-		LatestSupportedProtocolVersionAndHash: model.VersionAndHash{},
-	}, ts.Nodes()...)
 }

--- a/pkg/testsuite/transactions_framework.go
+++ b/pkg/testsuite/transactions_framework.go
@@ -241,6 +241,26 @@ func (t *TransactionFramework) CreateDelegationFromInput(inputAlias string, opts
 	return utxoledger.Outputs{input}, outputStates, []*mock.HDWallet{t.wallet}
 }
 
+// DelayedClaimingTransition transitions DelegationOutput into delayed claiming state by setting DelegationID and EndEpoch.
+func (t *TransactionFramework) DelayedClaimingTransition(inputAlias string, delegationEndEpoch iotago.EpochIndex) (utxoledger.Outputs, iotago.Outputs[iotago.Output], []*mock.HDWallet) {
+	input := t.Output(inputAlias)
+	if input.OutputType() != iotago.OutputDelegation {
+		panic(ierrors.Errorf("%s is not a delegation output, cannot transition to delayed claiming state", inputAlias))
+	}
+
+	delegationOutput, ok := input.Output().Clone().(*iotago.DelegationOutput)
+	if !ok {
+		panic(ierrors.Errorf("cloned output %s is not a delegation output, cannot transition to delayed claiming state", inputAlias))
+	}
+
+	if delegationOutput.DelegationID == iotago.EmptyDelegationID() {
+		delegationOutput.DelegationID = iotago.DelegationIDFromOutputID(input.OutputID())
+	}
+	delegationOutput.EndEpoch = delegationEndEpoch
+
+	return utxoledger.Outputs{input}, iotago.Outputs[iotago.Output]{delegationOutput}, []*mock.HDWallet{t.wallet}
+}
+
 func (t *TransactionFramework) DestroyAccount(alias string) (consumedInputs *utxoledger.Output, outputs iotago.Outputs[iotago.Output], signingWallets []*mock.HDWallet) {
 	output := t.Output(alias)
 


### PR DESCRIPTION
Use error handler instead of panicking.
Extend account test with delegation output claiming. Full test set will be implemented as part of the VM hardening that covers all edge cases. 
Remove some outdated TODOs. 