### PR TITLE
Remove block issuance via API signed by the node itself

### DIFF
--- a/components/blockissuer/component.go
+++ b/components/blockissuer/component.go
@@ -6,7 +6,6 @@ import (
 	"go.uber.org/dig"
 
 	"github.com/iotaledger/hive.go/app"
-	"github.com/iotaledger/iota-core/components/restapi"
 	"github.com/iotaledger/iota-core/pkg/blockfactory"
 	"github.com/iotaledger/iota-core/pkg/daemon"
 	"github.com/iotaledger/iota-core/pkg/protocol"
@@ -47,7 +46,6 @@ func provide(c *dig.Container) error {
 		return blockfactory.New(deps.Protocol,
 			blockfactory.WithTipSelectionTimeout(ParamsBlockIssuer.TipSelectionTimeout),
 			blockfactory.WithTipSelectionRetryInterval(ParamsBlockIssuer.TipSelectionRetryInterval),
-			blockfactory.WithIncompleteBlockAccepted(restapi.ParamsRestAPI.AllowIncompleteBlock),
 			blockfactory.WithRateSetterEnabled(ParamsBlockIssuer.RateSetterEnabled),
 		)
 	})

--- a/components/inx/component.go
+++ b/components/inx/component.go
@@ -22,16 +22,14 @@ func init() {
 		IsEnabled: func(c *dig.Container) bool {
 			return ParamsINX.Enabled
 		},
-		Provide:   provide,
-		Configure: configure,
-		Run:       run,
+		Provide: provide,
+		Run:     run,
 	}
 }
 
 var (
-	Component          *app.Component
-	deps               dependencies
-	blockIssuerAccount blockfactory.Account
+	Component *app.Component
+	deps      dependencies
 )
 
 type dependencies struct {
@@ -50,12 +48,6 @@ func provide(c *dig.Container) error {
 	}); err != nil {
 		Component.LogPanic(err)
 	}
-
-	return nil
-}
-
-func configure() error {
-	blockIssuerAccount = blockfactory.AccountFromParams(ParamsINX.BlockIssuerAccount, ParamsINX.BlockIssuerPrivateKey)
 
 	return nil
 }

--- a/components/inx/params.go
+++ b/components/inx/params.go
@@ -10,10 +10,6 @@ type ParametersINX struct {
 	Enabled bool `default:"false" usage:"whether the INX plugin is enabled"`
 	// the bind address on which the INX can be accessed from
 	BindAddress string `default:"localhost:9029" usage:"the bind address on which the INX can be accessed from"`
-	// BlockIssuerAccount the accountID of the account that will issue the blocks.
-	BlockIssuerAccount string `default:"" usage:"the accountID of the account that will issue the blocks"`
-	// BlockIssuerPrivateKey the private key of the account that will issue the blocks.
-	BlockIssuerPrivateKey string `default:"" usage:"the private key of the account that will issue the blocks"`
 }
 
 var ParamsINX = &ParametersINX{}

--- a/components/inx/server_blocks.go
+++ b/components/inx/server_blocks.go
@@ -130,7 +130,7 @@ func (s *Server) attachBlock(ctx context.Context, block *iotago.ProtocolBlock) (
 	mergedCtx, mergedCtxCancel := contextutils.MergeContexts(ctx, Component.Daemon().ContextStopped())
 	defer mergedCtxCancel()
 
-	blockID, err := deps.BlockIssuer.AttachBlock(mergedCtx, block, blockIssuerAccount)
+	blockID, err := deps.BlockIssuer.AttachBlock(mergedCtx, block)
 	if err != nil {
 		switch {
 		case ierrors.Is(err, blockfactory.ErrBlockAttacherInvalidBlock):

--- a/components/restapi/core/blocks.go
+++ b/components/restapi/core/blocks.go
@@ -110,7 +110,7 @@ func sendBlock(c echo.Context) (*apimodels.BlockCreatedResponse, error) {
 		return nil, echo.ErrUnsupportedMediaType
 	}
 
-	blockID, err := deps.BlockIssuer.AttachBlock(c.Request().Context(), iotaBlock, blockIssuerAccount)
+	blockID, err := deps.BlockIssuer.AttachBlock(c.Request().Context(), iotaBlock)
 	if err != nil {
 		switch {
 		case ierrors.Is(err, blockfactory.ErrBlockAttacherInvalidBlock):

--- a/components/restapi/core/component.go
+++ b/components/restapi/core/component.go
@@ -134,8 +134,7 @@ var (
 	Component *app.Component
 	deps      dependencies
 
-	blockIssuerAccount blockfactory.Account
-	features           = []string{}
+	features = []string{}
 )
 
 type dependencies struct {
@@ -156,12 +155,6 @@ func configure() error {
 	}
 
 	routeGroup := deps.RestRouteManager.AddRoute("core/v3")
-
-	if restapi.ParamsRestAPI.AllowIncompleteBlock {
-		AddFeature("allowIncompleteBlock")
-	}
-
-	blockIssuerAccount = blockfactory.AccountFromParams(restapi.ParamsRestAPI.BlockIssuerAccount, restapi.ParamsRestAPI.BlockIssuerPrivateKey)
 
 	routeGroup.GET(RouteInfo, func(c echo.Context) error {
 		resp := info()

--- a/components/restapi/params.go
+++ b/components/restapi/params.go
@@ -16,8 +16,6 @@ type ParametersRestAPI struct {
 	ProtectedRoutes []string `usage:"the HTTP REST routes which need to be called with authorization. Wildcards using * are allowed"`
 	// whether the debug logging for requests should be enabled
 	DebugRequestLoggerEnabled bool `default:"false" usage:"whether the debug logging for requests should be enabled"`
-	// AllowIncompleteBlock defines whether the node allows to fill in incomplete block and issue it for user.
-	AllowIncompleteBlock bool `default:"false" usage:"whether the node allows to fill in incomplete block and issue it for user"`
 	// MaxPageSize defines the maximum number of results per page.
 	MaxPageSize uint32 `default:"100" usage:"the maximum number of results per page"`
 	// RequestsMemoryCacheGranularity defines per how many slots a cache is created for big API requests.
@@ -36,12 +34,6 @@ type ParametersRestAPI struct {
 		// the maximum number of results that may be returned by an endpoint
 		MaxResults int `default:"1000" usage:"the maximum number of results that may be returned by an endpoint"`
 	}
-
-	// BlockIssuerAccount the accountID of the account that will issue the blocks.
-	BlockIssuerAccount string `default:"" usage:"the accountID of the account that will issue the blocks"`
-
-	// BlockIssuerPrivateKey the private key of the account that will issue the blocks.
-	BlockIssuerPrivateKey string `default:"" usage:"the private key of the account that will issue the blocks"`
 }
 
 var ParamsRestAPI = &ParametersRestAPI{

--- a/config_defaults.json
+++ b/config_defaults.json
@@ -65,7 +65,6 @@
       "/api/*"
     ],
     "debugRequestLoggerEnabled": false,
-    "allowIncompleteBlock": false,
     "maxPageSize": 100,
     "requestsMemoryCacheGranularity": 10,
     "maxRequestedSlotAge": 10,
@@ -75,9 +74,7 @@
     "limits": {
       "maxBodyLength": "1M",
       "maxResults": 1000
-    },
-    "blockIssuerAccount": "",
-    "blockIssuerPrivateKey": ""
+    }
   },
   "debugAPI": {
     "enabled": true,
@@ -155,8 +152,6 @@
   },
   "inx": {
     "enabled": false,
-    "bindAddress": "localhost:9029",
-    "blockIssuerAccount": "",
-    "blockIssuerPrivateKey": ""
+    "bindAddress": "localhost:9029"
   }
 }

--- a/deploy/ansible/roles/iota-core-node/templates/docker-compose-iota-core.yml.j2
+++ b/deploy/ansible/roles/iota-core-node/templates/docker-compose-iota-core.yml.j2
@@ -40,7 +40,6 @@ services:
       --profiling.bindAddress=0.0.0.0:6061
       --profiling.enabled=true
       --protocol.snapshot.path=/app/data/snapshot.bin
-      --restAPI.allowIncompleteBlock=true
       {% if 'node-01' in inventory_hostname or 'node-02' in inventory_hostname or 'node-03' in inventory_hostname %}
       --validator.enabled=true
       --validator.account={{validatorAccount}}
@@ -49,11 +48,6 @@ services:
       {% if 'node-01' in inventory_hostname %}
       --validator.ignoreBootstrapped=true
       {% endif %}
-      --restAPI.allowIncompleteBlock=true
-      --restAPI.blockIssuerAccount={{validatorAccount}}
-      --restAPI.blockIssuerPrivateKey={{validatorPrivKey}}
-      --inx.blockIssuerAccount={{validatorAccount}}
-      --inx.blockIssuerPrivateKey={{validatorPrivKey}}
       --p2p.peers=/dns/node-01.feature/tcp/14666/p2p/12D3KooWCrjmh4dUCWfGVQT6ivzArieJB9Z3eKdy2mdEEN95NDPS
       --p2p.externalMultiAddresses={{ ips | join(',') }}
       --p2p.identityPrivateKey={{p2pIdentityPrivateKey}}

--- a/documentation/docs/references/configuration.md
+++ b/documentation/docs/references/configuration.md
@@ -179,14 +179,11 @@ Example:
 | publicRoutes                   | The HTTP REST routes which can be called without authorization. Wildcards using \* are allowed  | array   | /health<br/>/api/routes<br/>/api/core/v3/info<br/>/api/core/v3/blocks\*<br/>/api/core/v3/transactions\*<br/>/api/core/v3/commitments\*<br/>/api/core/v3/outputs\*<br/>/api/core/v3/accounts\*<br/>/api/core/v3/validators\*<br/>/api/core/v3/rewards\*<br/>/api/core/v3/committee<br/>/api/debug/v2/\*<br/>/api/indexer/v2/\*<br/>/api/mqtt/v2 |
 | protectedRoutes                | The HTTP REST routes which need to be called with authorization. Wildcards using \* are allowed | array   | /api/\*                                                                                                                                                                                                                                                                                                                                |
 | debugRequestLoggerEnabled      | Whether the debug logging for requests should be enabled                                       | boolean | false                                                                                                                                                                                                                                                                                                                                 |
-| allowIncompleteBlock           | Whether the node allows to fill in incomplete block and issue it for user                      | boolean | false                                                                                                                                                                                                                                                                                                                                 |
 | maxPageSize                    | The maximum number of results per page                                                         | uint    | 100                                                                                                                                                                                                                                                                                                                                   |
 | requestsMemoryCacheGranularity | Defines per how many slots a cache is created for big API requests                             | uint    | 10                                                                                                                                                                                                                                                                                                                                    |
 | maxRequestedSlotAge            | The maximum age of a request that will be processed                                            | uint    | 10                                                                                                                                                                                                                                                                                                                                    |
 | [jwtAuth](#restapi_jwtauth)    | Configuration for jwtAuth                                                                      | object  |                                                                                                                                                                                                                                                                                                                                       |
 | [limits](#restapi_limits)      | Configuration for limits                                                                       | object  |                                                                                                                                                                                                                                                                                                                                       |
-| blockIssuerAccount             | The accountID of the account that will issue the blocks                                        | string  | ""                                                                                                                                                                                                                                                                                                                                    |
-| blockIssuerPrivateKey          | The private key of the account that will issue the blocks                                      | string  | ""                                                                                                                                                                                                                                                                                                                                    |
 
 ### <a id="restapi_jwtauth"></a> JwtAuth
 
@@ -228,7 +225,6 @@ Example:
         "/api/*"
       ],
       "debugRequestLoggerEnabled": false,
-      "allowIncompleteBlock": false,
       "maxPageSize": 100,
       "requestsMemoryCacheGranularity": 10,
       "maxRequestedSlotAge": 10,
@@ -238,9 +234,7 @@ Example:
       "limits": {
         "maxBodyLength": "1M",
         "maxResults": 1000
-      },
-      "blockIssuerAccount": "",
-      "blockIssuerPrivateKey": ""
+      }
     }
   }
 ```
@@ -499,12 +493,10 @@ Example:
 
 ## <a id="inx"></a> 14. Inx
 
-| Name                  | Description                                               | Type    | Default value    |
-| --------------------- | --------------------------------------------------------- | ------- | ---------------- |
-| enabled               | Whether the INX plugin is enabled                         | boolean | false            |
-| bindAddress           | The bind address on which the INX can be accessed from    | string  | "localhost:9029" |
-| blockIssuerAccount    | The accountID of the account that will issue the blocks   | string  | ""               |
-| blockIssuerPrivateKey | The private key of the account that will issue the blocks | string  | ""               |
+| Name        | Description                                            | Type    | Default value    |
+| ----------- | ------------------------------------------------------ | ------- | ---------------- |
+| enabled     | Whether the INX plugin is enabled                      | boolean | false            |
+| bindAddress | The bind address on which the INX can be accessed from | string  | "localhost:9029" |
 
 Example:
 
@@ -512,9 +504,7 @@ Example:
   {
     "inx": {
       "enabled": false,
-      "bindAddress": "localhost:9029",
-      "blockIssuerAccount": "",
-      "blockIssuerPrivateKey": ""
+      "bindAddress": "localhost:9029"
     }
   }
 ```

--- a/tools/docker-network/docker-compose.yml
+++ b/tools/docker-network/docker-compose.yml
@@ -16,13 +16,8 @@ services:
       --validator.ignoreBootstrapped=true
       --validator.account=0x907c02e9302e0f0571f10f885594e56d8c54ff0708ab7a39bc1b74d396b93b12
       --validator.privateKey=443a988ea61797651217de1f4662d4d6da11fd78e67f94511453bf6576045a05293dc170d9a59474e6d81cfba7f7d924c09b25d7166bcfba606e53114d0a758b
-      --restAPI.allowIncompleteBlock=true
-      --restAPI.blockIssuerAccount=0x907c02e9302e0f0571f10f885594e56d8c54ff0708ab7a39bc1b74d396b93b12
-      --restAPI.blockIssuerPrivateKey=443a988ea61797651217de1f4662d4d6da11fd78e67f94511453bf6576045a05293dc170d9a59474e6d81cfba7f7d924c09b25d7166bcfba606e53114d0a758b
       --inx.enabled=true
       --inx.bindAddress=0.0.0.0:9029
-      --inx.blockIssuerAccount=0x907c02e9302e0f0571f10f885594e56d8c54ff0708ab7a39bc1b74d396b93b12
-      --inx.blockIssuerPrivateKey=443a988ea61797651217de1f4662d4d6da11fd78e67f94511453bf6576045a05293dc170d9a59474e6d81cfba7f7d924c09b25d7166bcfba606e53114d0a758b
     volumes:
       - ./docker-network.snapshot:/app/data/snapshot.bin
       - ./config.json:/app/config.json:ro
@@ -54,13 +49,8 @@ services:
       --validator.enabled=true
       --validator.account=0x375358f92cc94750669598b0aaa55a6ff73310b90710e1fad524c0f911be0fea
       --validator.privateKey=3a5d39f8b60367a17fd54dac2a32c172c8e1fd6cf74ce65f1e13edba565f281705c1de274451db8de8182d64c6ee0dca3ae0c9077e0b4330c976976171d79064
-      --restAPI.allowIncompleteBlock=true
-      --restAPI.blockIssuerAccount=0x375358f92cc94750669598b0aaa55a6ff73310b90710e1fad524c0f911be0fea
-      --restAPI.blockIssuerPrivateKey=3a5d39f8b60367a17fd54dac2a32c172c8e1fd6cf74ce65f1e13edba565f281705c1de274451db8de8182d64c6ee0dca3ae0c9077e0b4330c976976171d79064
       --inx.enabled=true
       --inx.bindAddress=0.0.0.0:9029
-      --inx.blockIssuerAccount=0x375358f92cc94750669598b0aaa55a6ff73310b90710e1fad524c0f911be0fea
-      --inx.blockIssuerPrivateKey=3a5d39f8b60367a17fd54dac2a32c172c8e1fd6cf74ce65f1e13edba565f281705c1de274451db8de8182d64c6ee0dca3ae0c9077e0b4330c976976171d79064
     volumes:
       - ./docker-network.snapshot:/app/data/snapshot.bin
       - ./config.json:/app/config.json:ro
@@ -84,13 +74,8 @@ services:
       --validator.enabled=true
       --validator.account=0x6aee704f25558e8aa7630fed0121da53074188abc423b3c5810f80be4936eb6e
       --validator.privateKey=db39d2fde6301d313b108dc9db1ee724d0f405f6fde966bd776365bc5f4a5fb31e4b21eb51dcddf65c20db1065e1f1514658b23a3ddbf48d30c0efc926a9a648
-      --restAPI.allowIncompleteBlock=true
-      --restAPI.blockIssuerAccount=0x6aee704f25558e8aa7630fed0121da53074188abc423b3c5810f80be4936eb6e
-      --restAPI.blockIssuerPrivateKey=db39d2fde6301d313b108dc9db1ee724d0f405f6fde966bd776365bc5f4a5fb31e4b21eb51dcddf65c20db1065e1f1514658b23a3ddbf48d30c0efc926a9a648
       --inx.enabled=true
       --inx.bindAddress=0.0.0.0:9029
-      --inx.blockIssuerAccount=0x6aee704f25558e8aa7630fed0121da53074188abc423b3c5810f80be4936eb6e
-      --inx.blockIssuerPrivateKey=db39d2fde6301d313b108dc9db1ee724d0f405f6fde966bd776365bc5f4a5fb31e4b21eb51dcddf65c20db1065e1f1514658b23a3ddbf48d30c0efc926a9a648
     volumes:
       - ./docker-network.snapshot:/app/data/snapshot.bin
       - ./config.json:/app/config.json:ro
@@ -109,13 +94,8 @@ services:
       ${COMMON_CONFIG}
       ${MANUALPEERING_CONFIG}
       --p2p.identityPrivateKey=03feb3bcd25e57f75697bb329e6e0100680431e4c45c85bc013da2aea9e9d0345e08a0c37407dc62369deebc64cb0fb3ea26127d19d141ee7fb8eaa6b92019d7
-      --restAPI.allowIncompleteBlock=true
-      --restAPI.blockIssuerAccount=0xd057230f48fdf59ae093e2179857c590e960b05389399399ce69ad169a9c7f37
-      --restAPI.blockIssuerPrivateKey=dcf7adb000f03826f1964a3e5378874b1972c38229fb740a8e47f2c421cddcf9a54fafa44a88e4a6a37796526ea884f613a24d84337871226eb6360f022d8b39
       --inx.enabled=true
       --inx.bindAddress=0.0.0.0:9029
-      --inx.blockIssuerAccount=0xd057230f48fdf59ae093e2179857c590e960b05389399399ce69ad169a9c7f37
-      --inx.blockIssuerPrivateKey=dcf7adb000f03826f1964a3e5378874b1972c38229fb740a8e47f2c421cddcf9a54fafa44a88e4a6a37796526ea884f613a24d84337871226eb6360f022d8b39
     volumes:
       - ./docker-network.snapshot:/app/data/snapshot.bin
       - ./config.json:/app/config.json:ro
@@ -134,13 +114,8 @@ services:
       ${COMMON_CONFIG}
       ${MANUALPEERING_CONFIG}
       --p2p.identityPrivateKey=7d1491df3ef334dee988d6cdfc4b430b996d520bd63375a01d6754f8cee979b855b200fbea8c936ea1937a27e6ad72a7c9a21c1b17c2bd3c11f1f6994d813446
-      --restAPI.allowIncompleteBlock=true
-      --restAPI.blockIssuerAccount=0x7a9ec5d9c0c145bae03b20cbe481cfea306e688c00525b410eb8cb18a169ed7f
-      --restAPI.blockIssuerPrivateKey=0d8ecad4cefe927d2b6c64ee56576c52450f9a7a0113f96683cf8e8cc5c64264cb5ea14175ce649149ee41217c44aa70c3205b9939968449eae408727a71f91b
       --inx.enabled=true
       --inx.bindAddress=0.0.0.0:9029
-      --inx.blockIssuerAccount=0x7a9ec5d9c0c145bae03b20cbe481cfea306e688c00525b410eb8cb18a169ed7f
-      --inx.blockIssuerPrivateKey=0d8ecad4cefe927d2b6c64ee56576c52450f9a7a0113f96683cf8e8cc5c64264cb5ea14175ce649149ee41217c44aa70c3205b9939968449eae408727a71f91b
     volumes:
       - ./docker-network.snapshot:/app/data/snapshot.bin
       - ./config.json:/app/config.json:ro


### PR DESCRIPTION
The node itself should not be able to sign blocks for other parties. That should be handled by the clients themself.
This is only a temporary measure for our tests, and this PR should be merged when we improved our test framework.