### PR TITLE
Fix Delegation Stake Change Calculation

### DIFF
--- a/pkg/protocol/engine/ledger/ledger/ledger.go
+++ b/pkg/protocol/engine/ledger/ledger/ledger.go
@@ -500,7 +500,7 @@ func (l *Ledger) processCreatedAndConsumedAccountOutputs(stateDiff mempool.State
 
 			createdAccounts[accountID] = createdOutput
 		case iotago.OutputDelegation:
-			// The Delegation Output output was created or transitioned => determine later if we need to add the stake to the validator.
+			// The DelegationOutput was created or transitioned => determine later if we need to add the stake to the validator.
 			delegationOutput, _ := createdOutput.Output().(*iotago.DelegationOutput)
 			delegationID := delegationOutput.DelegationID
 			// Check if the output was newly created or if it was transitioned to delayed claiming.

--- a/pkg/tests/accounts_test.go
+++ b/pkg/tests/accounts_test.go
@@ -270,6 +270,7 @@ func Test_TransitionAccount(t *testing.T) {
 
 	latestParent = ts.CommitUntilSlot(block4Slot, activeNodes, block4)
 
+	// Transitioning to delayed claiming effectively removes the delegation, so we expect a negative delegation stake change.
 	ts.AssertAccountDiff(newAccountOutput.AccountID, block4Slot, &model.AccountDiff{
 		BICChange:              0,
 		PreviousUpdatedTime:    0,
@@ -280,7 +281,7 @@ func Test_TransitionAccount(t *testing.T) {
 		ValidatorStakeChange:   0,
 		StakeEndEpochChange:    0,
 		FixedCostChange:        0,
-		DelegationStakeChange:  0,
+		DelegationStakeChange:  -int64(delegatedAmount),
 	}, false, ts.Nodes()...)
 
 	ts.AssertAccountData(&accounts.AccountData{
@@ -291,7 +292,7 @@ func Test_TransitionAccount(t *testing.T) {
 		BlockIssuerKeys: iotago.NewBlockIssuerKeys(newAccountBlockIssuerKey),
 		StakeEndEpoch:   10,
 		FixedCost:       421,
-		DelegationStake: iotago.BaseToken(delegatedAmount),
+		DelegationStake: iotago.BaseToken(0),
 		ValidatorStake:  10000,
 	}, ts.Nodes()...)
 


### PR DESCRIPTION
Fix the delegation stake calculation upon slot commitment.

There were two issues:
- Using the Delegation ID of a Delegation Output directly, which may be zero, so it must be derived from the output ID first.
- A Delegation Output that was transitioned to Delayed Claiming was still counted as staking to that validator. However, that should not be the case. Consider the following case:
    - Create a Delegation Output `A` with a `Amount = Delegated Amount = 1000` and `Validator Address = 0x123`. That increases `0x123`'s delegated stake by 1000. Now we transition to delayed claiming and keep `Delegated Amount` the same, but remove all the value except for the required storage deposit, say, to `Amount = 10`. In the same transition we can create a new Delegation Output `B` with `Amount = Delegated Amount = 990` to the same validator. Now we've effectively delegated to the same validator twice with the same `990` tokens, and that stake is active as long as we don't consume `A`. We could repeat this procedure for a long time. Hence, as soon as we transition to delayed claiming, we need to subtract the delegated stake from the validator, so no Delegation Output can ever delegate the same tokens twice.