### PR TITLE
Exit on first error in docker-network run.sh

### DIFF
--- a/tools/docker-network/run.sh
+++ b/tools/docker-network/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Create a function to join an array of strings by a given character
 function join { local IFS="$1"; shift; echo "$*"; }


### PR DESCRIPTION
`tools/docker-network/run.sh` will not exit on the first uncaught error. See https://github.com/iotaledger/iota-sdk/actions/runs/6564215266/job/17830141249#step:7:696