### PR TITLE
Calculate Delegation End Epoch from the Future Bounded Commitment Index

### DIFF
--- a/pkg/protocol/engine/ledger/ledger/vm.go
+++ b/pkg/protocol/engine/ledger/ledger/vm.go
@@ -114,7 +114,7 @@ func (v *VM) ValidateSignatures(signedTransaction mempool.SignedTransaction, res
 				// If Delegation ID is zeroed, the output is in delegating state, which means its End Epoch is not set and we must use the
 				// "last epoch", which is the epoch index corresponding to the future bounded slot index minus 1.
 				apiForSlot := v.ledger.apiProvider.APIForSlot(commitmentInput.Slot)
-				futureBoundedSlotIndex := commitmentInput.Slot + iotago.SlotIndex(apiForSlot.ProtocolParameters().MinCommittableAge())
+				futureBoundedSlotIndex := commitmentInput.Slot + apiForSlot.ProtocolParameters().MinCommittableAge()
 				delegationEnd = apiForSlot.TimeProvider().EpochFromSlot(futureBoundedSlotIndex) - iotago.EpochIndex(1)
 			}
 


### PR DESCRIPTION
Calculate the end epoch for a delegation output from the future bounded commitment input slot index.

Consider this example for why this is necessary: Suppose we created a Delegation Output in Epoch 2, which means we set Start Epoch to 3 (the first epoch for which we delegated) and now we want to stop delegating and claim the rewards for epoch 3. Note that rewards become available with the commitment of the last slot of an epoch. So the rewards for epoch 3 become available when the last slot of epoch 3 is committed, which happens at some point at the beginning of epoch 4.
If we issue the block containing the claiming transaction at the beginning of epoch 4 and happen to pick exactly the slot in which rewards became available as a commitment input, then the corresponding epoch of that slot is 3 and due to the subtraction of 1 epoch (to account for the fact that we cannot be claiming rewards for the "current epoch" since it hasn't finished yet), we would end up requesting the rewards for delegation start = 3 and end = 2, which always yields 0.
This reward 0 would be injected as context to the VM while a client might have calculated it correctly by adding MinCA to the commitment input, which results in an undesirable discrepancy.

To rectify this, we can simply add MinCA to the commitment input slot index, which would result in the end epoch set to 3, because `epochForSlot(lastSlotOfEpochX + MinCA) = X+1`. At the same time, with this calculation we can never end up claiming rewards for an epoch x+1 when issuing a block in epoch x, since it's impossible to pick a commitment that is newer than Min CA, which is the desirable behavior.

Mostly unrelated but for completeness: A similar problem still exists if we make less strict assumptions like that we cannot pick the optimal commitment, i.e. one that is more than Min CA old. Then we could still issue a block in epoch 5 and have `epochFromSlot(commitment index + Min CA)` end up as epoch 4. But using Min CA here is a necessary trade-off to prevent anyone from _faking the future_, e.g. issue a block in epoch 4 but have the calculated epoch index end up as epoch 5. More on this: https://github.com/iotaledger/tips/blob/tip40/tips/TIP-0040/tip-0040.md#time-boundaries.
