### PR TITLE
Accept `slotIndex` query param in rewards API

### DIFF
--- a/components/restapi/core/accounts.go
+++ b/components/restapi/core/accounts.go
@@ -133,6 +133,7 @@ func rewardsByOutputID(c echo.Context) (*apimodels.ManaRewardsResponse, error) {
 	if err != nil {
 		return nil, ierrors.Wrapf(err, "failed to parse output ID %s", c.Param(restapipkg.ParameterOutputID))
 	}
+	slotIndex, _ := httpserver.ParseSlotQueryParam(c, restapipkg.ParameterSlotIndex)
 
 	utxoOutput, err := deps.Protocol.MainEngineInstance().Ledger.Output(outputID)
 	if err != nil {
@@ -164,17 +165,28 @@ func rewardsByOutputID(c echo.Context) (*apimodels.ManaRewardsResponse, error) {
 	case iotago.OutputDelegation:
 		//nolint:forcetypeassert
 		delegationOutput := utxoOutput.Output().(*iotago.DelegationOutput)
-		latestCommittedSlot := deps.Protocol.MainEngineInstance().SyncManager.LatestCommitment().Slot()
-		stakingEnd := delegationOutput.EndEpoch
-		// the output is in delayed calaiming state if endEpoch is set, otherwise we use latest possible epoch
-		if delegationOutput.EndEpoch == 0 {
-			stakingEnd = deps.Protocol.APIForSlot(latestCommittedSlot).TimeProvider().EpochFromSlot(deps.Protocol.MainEngineInstance().SyncManager.LatestCommitment().Slot())
+		delegationEnd := delegationOutput.EndEpoch
+		// If Delegation ID is zeroed, the output is in delegating state, which means its End Epoch is not set and we must use the
+		// "last epoch" for the rewards calculation.
+		// In this case the calculation must be consistent with the rewards calculation at execution time, so a client can specify
+		// a slot index explicitly, which should be equal to the slot it uses as the commitment input for the claiming transaction.
+		if delegationOutput.DelegationID.Empty() {
+			// The slot index may be unset for requests that do not want to issue a transaction, such as displaying estimated rewards,
+			// in which case we use latest committed slot.
+			if slotIndex == 0 {
+				slotIndex = deps.Protocol.MainEngineInstance().SyncManager.LatestCommitment().Slot()
+			}
+
+			apiForSlot := deps.Protocol.APIForSlot(slotIndex)
+			futureBoundedSlotIndex := slotIndex + apiForSlot.ProtocolParameters().MinCommittableAge()
+			delegationEnd = apiForSlot.TimeProvider().EpochFromSlot(futureBoundedSlotIndex) - iotago.EpochIndex(1)
 		}
+
 		reward, actualStart, actualEnd, err = deps.Protocol.MainEngineInstance().SybilProtection.DelegatorReward(
 			delegationOutput.ValidatorAddress.AccountID(),
 			delegationOutput.DelegatedAmount,
 			delegationOutput.StartEpoch,
-			stakingEnd,
+			delegationEnd,
 		)
 	}
 	if err != nil {


### PR DESCRIPTION
Accept `slotIndex` query param in rewards API.

When calculating rewards in the CORE API for a delegation output in its regular state (no delayed claiming), the delegation end epoch is set to 0. That means when the output is consumed we claim up until the "current epoch".
In the API we currently calculate that current epoch as `EpochFromSlot(deps.Protocol.MainEngineInstance().SyncManager.LatestCommitment().Slot())`.

When we then issue a transaction claiming rewards, the ledger/vm component in the node calculates the rewards again and injects it as context to the VM, which is the source of truth for tx execution. That calculation here, for what the "current epoch" is, is done based on the provided commitment input.
So in order to always end up with the exact same calculation, the client needs to request rewards, which uses latest committed slot, and then use the exact same commitment as the commitment input for the transaction. However, the rewards API only returns the start and end epochs of the calculation, so the client can't figure out what commitment was used exactly. Because this dependency is fairly invovled, it seems unlikely that a client would actually implement this logic / make sure this matches.

Hence, if a client doesn't handle this case specifically and just does these requests for rewards calculation and for retrieving a commitment concurrently, this could sometimes be problematic. If a client is unlucky and the node commits a new slot in between the two, then latest committed slot is different in those two requests. 

To make this more resilient, this PR lets the client provide the slot commitment as input to the rewards API instead, so they can be sure the calculation they do before issuing the transaction will be identical to the one done at execution time.

This parameter is only recommended to be provided when requesting rewards for a Delegation Output in delegating state (i.e. when Delegation ID is zeroed). The parameter can still be omitted, in which case the latest committed slot will be used, so that, for example, a wallet that just wants to display estimated rewards doesn't have to provide this param.

Finally, this PR also subtracts 1 from the epoch derived from the provided slot index, which wasn't done previously, per [TIP-40](https://github.com/iotaledger/tips/blob/tip40/tips/TIP-0040/tip-0040.md#calculations-5).