### PR TITLE
Fix incorrect handling of mempool.StateMetadata in ListenToAcceptedTransactions

### DIFF
--- a/components/inx/server_utxo.go
+++ b/components/inx/server_utxo.go
@@ -353,7 +353,8 @@ func (s *Server) ListenToAcceptedTransactions(_ *inx.NoParams, srv inx.INX_Liste
 		if err := transactionMetadata.Inputs().ForEach(func(stateMetadata mempool.StateMetadata) error {
 			spentOutput, ok := stateMetadata.State().(*utxoledger.Output)
 			if !ok {
-				return ierrors.Errorf("unexpected state metadata type: %T", stateMetadata.State())
+				// not an Output, so we don't need to send it (could be MockedState, Commitment, BlockIssuanceCreditInput, RewardInput, etc.)
+				return nil
 			}
 
 			inxSpent, err := NewLedgerSpent(utxoledger.NewSpent(spentOutput, transactionMetadata.ID(), slot))
@@ -372,7 +373,8 @@ func (s *Server) ListenToAcceptedTransactions(_ *inx.NoParams, srv inx.INX_Liste
 		if err := transactionMetadata.Outputs().ForEach(func(stateMetadata mempool.StateMetadata) error {
 			output, ok := stateMetadata.State().(*utxoledger.Output)
 			if !ok {
-				return ierrors.Errorf("unexpected state metadata type: %T", stateMetadata.State())
+				// not an Output, so we don't need to send it (could be MockedState, Commitment, BlockIssuanceCreditInput, RewardInput, etc.)
+				return nil
 			}
 
 			inxOutput, err := NewLedgerOutput(output)


### PR DESCRIPTION
Fix the following error:
```
docker-network-node-1-validator-1  | 2023-11-16T12:23:32Z       ERROR   INX     app@v0.0.0-20231110191152-7135670285dc/component.go:115 error creating payload: unexpected state metadata type: *iotago.Commitment
```