### PR TITLE
Fix bugs when force committing slots.

### DIFF
--- a/pkg/protocol/block_dispatcher.go
+++ b/pkg/protocol/block_dispatcher.go
@@ -323,6 +323,7 @@ func (b *BlockDispatcher) processWarpSyncResponse(commitmentID iotago.Commitment
 
 	if len(blockIDs) == 0 {
 		forceCommitmentFunc()
+
 		return nil
 	}
 

--- a/pkg/protocol/engine/engine.go
+++ b/pkg/protocol/engine/engine.go
@@ -437,6 +437,7 @@ func (e *Engine) acceptanceHandler() {
 		e.Ledger.TrackBlock(block)
 		e.SybilProtection.TrackBlock(block)
 		e.UpgradeOrchestrator.TrackValidationBlock(block)
+		e.TipSelection.SetAcceptanceTime(block.IssuingTime())
 
 		e.Events.AcceptedBlockProcessed.Trigger(block)
 	}, event.WithWorkerPool(wp))

--- a/pkg/protocol/engine/notarization/slotnotarization/manager.go
+++ b/pkg/protocol/engine/notarization/slotnotarization/manager.go
@@ -15,6 +15,7 @@ import (
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/blocks"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/ledger"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/notarization"
+	"github.com/iotaledger/iota-core/pkg/protocol/engine/tipselection"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/upgrade"
 	"github.com/iotaledger/iota-core/pkg/protocol/sybilprotection"
 	"github.com/iotaledger/iota-core/pkg/storage"
@@ -34,6 +35,7 @@ type Manager struct {
 	ledger              ledger.Ledger
 	sybilProtection     sybilprotection.SybilProtection
 	upgradeOrchestrator upgrade.Orchestrator
+	tipSelection        tipselection.TipSelection
 
 	storage *storage.Storage
 
@@ -57,6 +59,7 @@ func NewProvider() module.Provider[*engine.Engine, notarization.Notarization] {
 
 			m.ledger = e.Ledger
 			m.sybilProtection = e.SybilProtection
+			m.tipSelection = e.TipSelection
 			m.attestation = e.Attestations
 			m.upgradeOrchestrator = e.UpgradeOrchestrator
 
@@ -110,6 +113,15 @@ func (m *Manager) ForceCommit(slot iotago.SlotIndex) (*model.Commitment, error) 
 	if m.WasStopped() {
 		return nil, ierrors.New("notarization manager was stopped")
 	}
+
+	// When force committing set acceptance time in TipSelection to the end of the epoch
+	// that is LivenessThresholdUpperBound in the future from the committed slot,
+	// so that all the unaccepted blocks in force committed slot are orphaned.
+	// The value must be at least LivenessThresholdUpperBound in the future.
+	// This is to avoid the situation in which future cone of those blocks becomes accepted after force-committing the slot.
+	// This would cause issues with consistency as it's impossible to add blocks to a committed slot.
+	artificialAcceptanceTime := m.apiProvider.APIForSlot(slot).TimeProvider().SlotEndTime(slot).Add(m.apiProvider.APIForSlot(slot).ProtocolParameters().LivenessThresholdUpperBound())
+	m.tipSelection.SetAcceptanceTime(artificialAcceptanceTime)
 
 	commitment, err := m.createCommitment(slot)
 	if err != nil {

--- a/pkg/protocol/engine/tipselection/v1/provider.go
+++ b/pkg/protocol/engine/tipselection/v1/provider.go
@@ -8,7 +8,6 @@ import (
 	"github.com/iotaledger/hive.go/runtime/module"
 	"github.com/iotaledger/hive.go/runtime/options"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine"
-	"github.com/iotaledger/iota-core/pkg/protocol/engine/blocks"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/tipmanager"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/tipselection"
 	iotago "github.com/iotaledger/iota.go/v4"
@@ -23,10 +22,6 @@ func NewProvider(opts ...options.Option[TipSelection]) module.Provider[*engine.E
 			// wait for submodules to be constructed (so all of their properties are available)
 			module.OnAllConstructed(func() {
 				t.Construct(e.TipManager, e.Ledger.ConflictDAG(), e.Ledger.MemPool().TransactionMetadata, func() iotago.BlockIDs { return lo.Keys(e.EvictionState.ActiveRootBlocks()) }, DynamicLivenessThreshold(e.SybilProtection.SeatManager().OnlineCommittee().Size))
-
-				e.Events.AcceptedBlockProcessed.Hook(func(block *blocks.Block) {
-					t.SetAcceptanceTime(block.IssuingTime())
-				})
 			}, e.TipManager, e.Ledger, e.SybilProtection)
 		})
 


### PR DESCRIPTION
This PR contains two fixes that are related:
* Orphan non-accepted blocks before force-committing a slot. This led to committing a slot without orphaning non-accepted blocks inside, whose future cone was later incorrectly accepted.
* Do not fan-out event to TipSelection and Notarization, but call them sequentially. This could lead to a race-condition between marking blocks as orphaned and creating a committment. Under normal conditions this is not a problem, but it could become a problem if there was a jump in acceptance time bigger than LivenessThreshold.