### PR TITLE
Fix: MainEngine should not become a candidate itself.

### DIFF
--- a/pkg/protocol/chains.go
+++ b/pkg/protocol/chains.go
@@ -134,7 +134,7 @@ func (c *Chains) initChainSwitching(chainSwitchingThreshold iotago.SlotIndex) (s
 func (c *Chains) initHeaviestCandidateTracking(candidateVar reactive.Variable[*Chain], weightVar func(*Chain) reactive.Variable[uint64], newCandidate *Chain) (unsubscribe func()) {
 	return weightVar(newCandidate).OnUpdate(func(_ uint64, newWeight uint64) {
 		// abort if the candidate is not heavier than the main chain.
-		if mainChain := c.Main.Get(); mainChain != nil && newWeight <= mainChain.VerifiedWeight.Get() {
+		if mainChain := c.Main.Get(); newCandidate == mainChain || newWeight <= mainChain.VerifiedWeight.Get() {
 			return
 		}
 

--- a/pkg/protocol/engines.go
+++ b/pkg/protocol/engines.go
@@ -58,7 +58,6 @@ func newEngines(protocol *Protocol) *Engines {
 
 		e.Shutdown.OnTrigger(func() {
 			shutdown()
-			e.worker.Shutdown().ShutdownComplete.Wait()
 
 			e.Stopped.Trigger()
 		})

--- a/pkg/protocol/protocol.go
+++ b/pkg/protocol/protocol.go
@@ -163,8 +163,9 @@ func (p *Protocol) initSubcomponents(networkEndpoint network.Endpoint) (shutdown
 		p.AttestationsProtocol.Shutdown()
 		p.WarpSyncProtocol.Shutdown()
 		p.Network.Shutdown()
-		p.Workers.Shutdown()
+		p.Workers.WaitChildren()
 		p.Engines.Shutdown.Trigger()
+		p.Workers.Shutdown()
 	}
 }
 

--- a/pkg/testsuite/mock/node.go
+++ b/pkg/testsuite/mock/node.go
@@ -111,7 +111,7 @@ func NewNode(t *testing.T, net *Network, partition string, name string, validato
 		Workers:   workerpool.NewGroup(name),
 
 		logHandler:          logHandler,
-		enableEngineLogging: true,
+		enableEngineLogging: false,
 
 		attachedBlocks: make([]*blocks.Block, 0),
 	}

--- a/pkg/testsuite/mock/node.go
+++ b/pkg/testsuite/mock/node.go
@@ -157,8 +157,8 @@ func (n *Node) Initialize(failOnBlockFiltered bool, opts ...options.Option[proto
 }
 
 func (n *Node) hookEvents() {
-	n.Protocol.Chains.HeaviestAttestedCandidate.OnUpdate(func(prevHeaviestAttestedCandidate *protocol.Chain, heaviestAttestedCandidate *protocol.Chain) {
-		if prevHeaviestAttestedCandidate != nil {
+	n.Protocol.Chains.HeaviestAttestedCandidate.OnUpdate(func(_ *protocol.Chain, heaviestAttestedCandidate *protocol.Chain) {
+		if heaviestAttestedCandidate != nil {
 			n.forkDetectedCount.Add(1)
 
 			heaviestAttestedCandidate.Engine.OnUpdate(func(prevEngine *engine.Engine, newEngine *engine.Engine) {


### PR DESCRIPTION
This PR fixes a problem where the MainEngine became a candidate, causing its engine to be shut down once we find an actual candidate.

It also fixes a shutdown problem where the Workers need to be shutdown as the last thing we do as the reactive framework needs workers also for the shutdown (to step out of execution).

To make sure, that all workers shut down safely, we should shut down the workers only once from the outside rather than inside the components. Otherwise it can happen that 1 pool that is still running tries to submit things to a different pool that was already shutdown.