### PR TITLE
Fix wrong included slot in INX accepted transactions stream

### DIFF
--- a/components/inx/server_utxo.go
+++ b/components/inx/server_utxo.go
@@ -17,13 +17,18 @@ import (
 	iotago "github.com/iotaledger/iota.go/v4"
 )
 
-func NewLedgerOutput(o *utxoledger.Output) (*inx.LedgerOutput, error) {
+func NewLedgerOutput(o *utxoledger.Output, slotIncluded ...iotago.SlotIndex) (*inx.LedgerOutput, error) {
 	latestCommitment := deps.Protocol.MainEngineInstance().SyncManager.LatestCommitment()
+
+	includedSlot := o.SlotBooked()
+	if len(slotIncluded) > 0 {
+		includedSlot = slotIncluded[0]
+	}
 
 	l := &inx.LedgerOutput{
 		OutputId:   inx.NewOutputId(o.OutputID()),
 		BlockId:    inx.NewBlockId(o.BlockID()),
-		SlotBooked: uint32(o.SlotBooked()),
+		SlotBooked: uint32(includedSlot),
 		Output: &inx.RawOutput{
 			Data: o.Bytes(),
 		},
@@ -32,7 +37,6 @@ func NewLedgerOutput(o *utxoledger.Output) (*inx.LedgerOutput, error) {
 		},
 	}
 
-	includedSlot := o.SlotBooked()
 	if includedSlot > 0 &&
 		includedSlot <= latestCommitment.Slot() &&
 		includedSlot >= deps.Protocol.CommittedAPI().ProtocolParameters().GenesisSlot() {
@@ -394,7 +398,8 @@ func (s *Server) ListenToAcceptedTransactions(_ *inx.NoParams, srv inx.INX_Liste
 				return nil
 			}
 
-			inxOutput, err := NewLedgerOutput(output)
+			// we need to pass the slot of the accepted transaction here, because the "SlotBooked" in the output is 0.
+			inxOutput, err := NewLedgerOutput(output, slot)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This fixes the regression I introduced with my recent refactorings.

Before in the `ListenToAcceptedTransactions` we passed the slot of the tx as the creation slots of the Outputs.
I simplified that by using the `SlotBooked` of the mempool output itself, but this always seems to be 0.
I reverted that change and now the indexer works correctly again.

What I didn't see in our codebase is, where we set the correct `SlotBooked` at all? :thinking: 