### PR TITLE
Fix BucketManager deadlock and shutdown issue

### DIFF
--- a/pkg/storage/database/db_instance.go
+++ b/pkg/storage/database/db_instance.go
@@ -64,10 +64,6 @@ func NewDBInstance(dbConfig Config, openedCallback func(d *DBInstance)) *DBInsta
 
 	dbInstance.healthTracker = storeHealthTracker
 
-	if openedCallback != nil {
-		openedCallback(dbInstance)
-	}
-
 	return dbInstance
 }
 

--- a/pkg/storage/database/db_instance.go
+++ b/pkg/storage/database/db_instance.go
@@ -34,18 +34,23 @@ func NewDBInstance(dbConfig Config, openedCallback func(d *DBInstance)) *DBInsta
 	// lockedKVStore and the underlying openableKVStore don't handle opening and closing the underlying store by themselves,
 	// but delegate that to the entity that constructed it. It needs to be done like that, because opening and closing the underlying store also
 	// modifies the state of the DBInstance. Other methods (e.g. Flush) that don't modify the state of DBInstance can be handled directly.
-	lockableKVStore := newLockedKVStore(db, func() {
+	lockableKVStore := newLockedKVStore(db, func() error {
 		if dbInstance.isClosed.Load() {
 			storeInstanceMutex.Lock()
 			defer storeInstanceMutex.Unlock()
 
 			if dbInstance.isClosed.Load() {
-				dbInstance.Open()
+				if err := dbInstance.Open(); err != nil {
+					return err
+				}
+
 				if openedCallback != nil {
 					openedCallback(dbInstance)
 				}
 			}
 		}
+
+		return nil
 	}, func() {
 		dbInstance.CloseWithoutLocking()
 	})
@@ -78,7 +83,9 @@ func (d *DBInstance) Flush() {
 	defer d.store.UnlockAccess()
 
 	if !d.isClosed.Load() {
-		_ = d.store.instance().Flush()
+		if instance, err := d.store.instance(); err == nil {
+			_ = instance.Flush()
+		}
 	}
 }
 
@@ -109,13 +116,13 @@ func (d *DBInstance) CloseWithoutLocking() {
 
 // Open re-opens a closed DBInstance. It must only be called while holding a lock on DBInstance,
 // otherwise it might cause a race condition and corruption of node's state.
-func (d *DBInstance) Open() {
+func (d *DBInstance) Open() error {
 	if !d.isClosed.Load() {
-		panic("cannot open DBInstance that is not closed")
+		panic(ErrDatabaseNotClosed)
 	}
 
 	if d.isShutdown.Load() {
-		panic("cannot open DBInstance that is shutdown")
+		return ErrDatabaseShutdown
 	}
 
 	d.store.Replace(lo.PanicOnErr(StoreWithDefaultSettings(d.dbConfig.Directory, false, d.dbConfig.Engine)))
@@ -123,8 +130,11 @@ func (d *DBInstance) Open() {
 	d.isClosed.Store(false)
 
 	if err := d.healthTracker.MarkCorrupted(); err != nil {
+		// panic immediately as in this case the database state is corrupted
 		panic(err)
 	}
+
+	return nil
 }
 
 func (d *DBInstance) LockAccess() {

--- a/pkg/storage/database/errors.go
+++ b/pkg/storage/database/errors.go
@@ -3,7 +3,9 @@ package database
 import "github.com/iotaledger/hive.go/ierrors"
 
 var (
-	ErrEpochPruned     = ierrors.New("epoch pruned")
-	ErrNoPruningNeeded = ierrors.New("no pruning needed")
-	ErrDatabaseFull    = ierrors.New("database full")
+	ErrEpochPruned       = ierrors.New("epoch pruned")
+	ErrNoPruningNeeded   = ierrors.New("no pruning needed")
+	ErrDatabaseFull      = ierrors.New("database full")
+	ErrDatabaseShutdown  = ierrors.New("cannot open DBInstance that is shutdown")
+	ErrDatabaseNotClosed = ierrors.New("cannot open DBInstance that is not closed")
 )

--- a/pkg/storage/database/lockedkvstore.go
+++ b/pkg/storage/database/lockedkvstore.go
@@ -13,7 +13,7 @@ type lockedKVStore struct {
 	accessMutex *syncutils.StarvingMutex
 }
 
-func newLockedKVStore(storeInstance kvstore.KVStore, openStoreIfNecessary func(), closeStore func()) *lockedKVStore {
+func newLockedKVStore(storeInstance kvstore.KVStore, openStoreIfNecessary func() error, closeStore func()) *lockedKVStore {
 	return &lockedKVStore{
 		openableKVStore: newOpenableKVStore(storeInstance, openStoreIfNecessary, closeStore),
 		accessMutex:     syncutils.NewStarvingMutex(),


### PR DESCRIPTION
Resolves the issue mentioned in https://github.com/iotaledger/iota-core/issues/542#issuecomment-1829876778 that was missed in the earlier PR. 

Resolves a deadlock when creating new DBInstance and improves the way DBInstance LRU cache is updated. 