### PR TITLE
Fix decay not being applied until "current epoch" in reward calculation

### DIFF
--- a/components/restapi/core/accounts.go
+++ b/components/restapi/core/accounts.go
@@ -185,7 +185,7 @@ func rewardsByOutputID(c echo.Context) (*api.ManaRewardsResponse, error) {
 	}
 
 	var reward iotago.Mana
-	var actualStart, actualEnd iotago.EpochIndex
+	var firstRewardEpoch, lastRewardEpoch iotago.EpochIndex
 	switch utxoOutput.OutputType() {
 	case iotago.OutputAccount:
 		//nolint:forcetypeassert
@@ -198,33 +198,38 @@ func rewardsByOutputID(c echo.Context) (*api.ManaRewardsResponse, error) {
 		//nolint:forcetypeassert
 		stakingFeature := feature.(*iotago.StakingFeature)
 
+		apiForSlot := deps.Protocol.APIForSlot(slotIndex)
+		futureBoundedSlotIndex := slotIndex + apiForSlot.ProtocolParameters().MinCommittableAge()
+		claimingEpoch := apiForSlot.TimeProvider().EpochFromSlot(futureBoundedSlotIndex)
+
 		// check if the account is a validator
-		reward, actualStart, actualEnd, err = deps.Protocol.Engines.Main.Get().SybilProtection.ValidatorReward(
+		reward, firstRewardEpoch, lastRewardEpoch, err = deps.Protocol.Engines.Main.Get().SybilProtection.ValidatorReward(
 			accountOutput.AccountID,
-			stakingFeature.StakedAmount,
-			stakingFeature.StartEpoch,
-			stakingFeature.EndEpoch,
+			stakingFeature,
+			claimingEpoch,
 		)
 
 	case iotago.OutputDelegation:
 		//nolint:forcetypeassert
 		delegationOutput := utxoOutput.Output().(*iotago.DelegationOutput)
 		delegationEnd := delegationOutput.EndEpoch
+		apiForSlot := deps.Protocol.APIForSlot(slotIndex)
+		futureBoundedSlotIndex := slotIndex + apiForSlot.ProtocolParameters().MinCommittableAge()
+		claimingEpoch := apiForSlot.TimeProvider().EpochFromSlot(futureBoundedSlotIndex)
 		// If Delegation ID is zeroed, the output is in delegating state, which means its End Epoch is not set and we must use the
 		// "last epoch" for the rewards calculation.
 		// In this case the calculation must be consistent with the rewards calculation at execution time, so a client can specify
 		// a slot index explicitly, which should be equal to the slot it uses as the commitment input for the claiming transaction.
 		if delegationOutput.DelegationID.Empty() {
-			apiForSlot := deps.Protocol.APIForSlot(slotIndex)
-			futureBoundedSlotIndex := slotIndex + apiForSlot.ProtocolParameters().MinCommittableAge()
-			delegationEnd = apiForSlot.TimeProvider().EpochFromSlot(futureBoundedSlotIndex) - iotago.EpochIndex(1)
+			delegationEnd = claimingEpoch - iotago.EpochIndex(1)
 		}
 
-		reward, actualStart, actualEnd, err = deps.Protocol.Engines.Main.Get().SybilProtection.DelegatorReward(
+		reward, firstRewardEpoch, lastRewardEpoch, err = deps.Protocol.Engines.Main.Get().SybilProtection.DelegatorReward(
 			delegationOutput.ValidatorAddress.AccountID(),
 			delegationOutput.DelegatedAmount,
 			delegationOutput.StartEpoch,
 			delegationEnd,
+			claimingEpoch,
 		)
 	}
 	if err != nil {
@@ -232,8 +237,8 @@ func rewardsByOutputID(c echo.Context) (*api.ManaRewardsResponse, error) {
 	}
 
 	return &api.ManaRewardsResponse{
-		StartEpoch: actualStart,
-		EndEpoch:   actualEnd,
+		StartEpoch: firstRewardEpoch,
+		EndEpoch:   lastRewardEpoch,
 		Rewards:    reward,
 	}, nil
 }

--- a/pkg/protocol/sybilprotection/sybilprotection.go
+++ b/pkg/protocol/sybilprotection/sybilprotection.go
@@ -16,12 +16,18 @@ type SybilProtection interface {
 	EligibleValidators(epoch iotago.EpochIndex) (accounts.AccountsData, error)
 	OrderedRegisteredCandidateValidatorsList(epoch iotago.EpochIndex) ([]*api.ValidatorResponse, error)
 	IsCandidateActive(validatorID iotago.AccountID, epoch iotago.EpochIndex) (bool, error)
-	// ValidatorReward returns the amount of mana that a validator has earned in a given epoch range.
-	// The actual used epoch range is returned, only until usedEnd the decay was applied.
-	ValidatorReward(validatorID iotago.AccountID, stakeAmount iotago.BaseToken, epochStart, epochEnd iotago.EpochIndex) (validatorReward iotago.Mana, decayedStart, decayedEnd iotago.EpochIndex, err error)
+	// ValidatorReward returns the amount of mana that a validator with the given staking feature has earned in the feature's epoch range.
+	//
+	// The first epoch in which rewards existed is returned (firstRewardEpoch).
+	// Since the validator may still be active and the EndEpoch might be in the future, the epoch until which rewards were calculated is returned in addition to the first epoch in which rewards existed (lastRewardEpoch).
+	// The rewards are decayed until claimingEpoch, which should be set to the epoch in which the rewards would be claimed.
+	ValidatorReward(validatorID iotago.AccountID, stakingFeature *iotago.StakingFeature, claimingEpoch iotago.EpochIndex) (validatorReward iotago.Mana, firstRewardEpoch iotago.EpochIndex, lastRewardEpoch iotago.EpochIndex, err error)
 	// DelegatorReward returns the amount of mana that a delegator has earned in a given epoch range.
-	// The actual used epoch range is returned, only until usedEnd the decay was applied.
-	DelegatorReward(validatorID iotago.AccountID, delegatedAmount iotago.BaseToken, epochStart, epochEnd iotago.EpochIndex) (delegatorsReward iotago.Mana, decayedStart, decayedEnd iotago.EpochIndex, err error)
+	//
+	// The first epoch in which rewards existed is returned (firstRewardEpoch).
+	// Since the Delegation Output's EndEpoch might be unset due to an ongoing delegation, the epoch until which rewards were calculated is also returned (lastRewardEpoch).
+	// The rewards are decayed until claimingEpoch, which should be set to the epoch in which the rewards would be claimed.
+	DelegatorReward(validatorID iotago.AccountID, delegatedAmount iotago.BaseToken, epochStart iotago.EpochIndex, epochEnd iotago.EpochIndex, claimingEpoch iotago.EpochIndex) (delegatorReward iotago.Mana, firstRewardEpoch iotago.EpochIndex, lastRewardEpoch iotago.EpochIndex, err error)
 	SeatManager() seatmanager.SeatManager
 	CommitSlot(iotago.SlotIndex) (iotago.Identifier, iotago.Identifier, error)
 	Import(io.ReadSeeker) error

--- a/pkg/protocol/sybilprotection/sybilprotectionv1/performance/testsuite_test.go
+++ b/pkg/protocol/sybilprotection/sybilprotectionv1/performance/testsuite_test.go
@@ -164,14 +164,19 @@ func (t *TestSuite) AssertEpochRewards(epoch iotago.EpochIndex, actions map[stri
 		poolRewards := t.poolRewards[epoch][alias].PoolRewards
 		expectedValidatorReward := t.validatorReward(alias, epoch, t.epochStats[epoch].ProfitMargin, uint64(poolRewards), uint64(action.ValidatorStake), uint64(action.PoolStake), uint64(action.FixedCost), action)
 
+		mockStakingFeature := &iotago.StakingFeature{
+			StakedAmount: actions[alias].ValidatorStake,
+			StartEpoch:   epoch,
+			EndEpoch:     epoch,
+		}
 		accountID := t.Account(alias, true)
-		actualValidatorReward, _, _, err := t.Instance.ValidatorReward(accountID, actions[alias].ValidatorStake, epoch, epoch)
+		actualValidatorReward, _, _, err := t.Instance.ValidatorReward(accountID, mockStakingFeature, epoch)
 		require.NoError(t.T, err)
 		require.Equal(t.T, expectedValidatorReward, actualValidatorReward)
 
 		for delegatedAmount := range action.Delegators {
 			expectedDelegatorReward := t.delegatorReward(epoch, t.epochStats[epoch].ProfitMargin, uint64(poolRewards), uint64(delegatedAmount), uint64(action.PoolStake), uint64(action.FixedCost), action)
-			actualDelegatorReward, _, _, err := t.Instance.DelegatorReward(accountID, iotago.BaseToken(delegatedAmount), epoch, epoch)
+			actualDelegatorReward, _, _, err := t.Instance.DelegatorReward(accountID, iotago.BaseToken(delegatedAmount), epoch, epoch, epoch)
 			require.NoError(t.T, err)
 			require.Equal(t.T, expectedDelegatorReward, actualDelegatorReward)
 		}
@@ -180,29 +185,39 @@ func (t *TestSuite) AssertEpochRewards(epoch iotago.EpochIndex, actions map[stri
 }
 
 func (t *TestSuite) AssertNoReward(alias string, epoch iotago.EpochIndex, actions map[string]*EpochActions) {
+	mockStakingFeature := &iotago.StakingFeature{
+		StakedAmount: actions[alias].ValidatorStake,
+		StartEpoch:   epoch,
+		EndEpoch:     epoch,
+	}
 	accID := t.Account(alias, false)
-	actualValidatorReward, _, _, err := t.Instance.ValidatorReward(accID, actions[alias].ValidatorStake, epoch, epoch)
+	actualValidatorReward, _, _, err := t.Instance.ValidatorReward(accID, mockStakingFeature, epoch)
 	require.NoError(t.T, err)
 	require.Equal(t.T, iotago.Mana(0), actualValidatorReward)
 	action, exists := actions[alias]
 	require.True(t.T, exists)
 	for delegatedAmount := range action.Delegators {
-		actualDelegatorReward, _, _, err := t.Instance.DelegatorReward(accID, iotago.BaseToken(delegatedAmount), epoch, epoch)
+		actualDelegatorReward, _, _, err := t.Instance.DelegatorReward(accID, iotago.BaseToken(delegatedAmount), epoch, epoch, epoch)
 		require.NoError(t.T, err)
 		require.Equal(t.T, iotago.Mana(0), actualDelegatorReward)
 	}
 }
 
 func (t *TestSuite) AssertRewardForDelegatorsOnly(alias string, epoch iotago.EpochIndex, actions map[string]*EpochActions) {
+	mockStakingFeature := &iotago.StakingFeature{
+		StakedAmount: actions[alias].ValidatorStake,
+		StartEpoch:   epoch,
+		EndEpoch:     epoch,
+	}
 	accID := t.Account(alias, false)
-	actualValidatorReward, _, _, err := t.Instance.ValidatorReward(accID, actions[alias].ValidatorStake, epoch, epoch)
+	actualValidatorReward, _, _, err := t.Instance.ValidatorReward(accID, mockStakingFeature, epoch)
 	require.NoError(t.T, err)
 	require.Equal(t.T, iotago.Mana(0), actualValidatorReward)
 	action, exists := actions[alias]
 	require.True(t.T, exists)
 
 	for delegatedAmount := range action.Delegators {
-		actualDelegatorReward, _, _, err := t.Instance.DelegatorReward(accID, iotago.BaseToken(delegatedAmount), epoch, epoch)
+		actualDelegatorReward, _, _, err := t.Instance.DelegatorReward(accID, iotago.BaseToken(delegatedAmount), epoch, epoch, epoch)
 		expectedDelegatorReward := t.delegatorReward(epoch, t.epochStats[epoch].ProfitMargin, uint64(t.poolRewards[epoch][alias].PoolRewards), uint64(delegatedAmount), uint64(action.PoolStake), uint64(action.FixedCost), action)
 
 		require.NoError(t.T, err)
@@ -320,12 +335,18 @@ func (t *TestSuite) calculateExpectedRewards(epochsCount int, epochActions map[s
 		delegatorRewardPerAccount[epoch] = make(map[string]iotago.Mana)
 		validatorRewardPerAccount[epoch] = make(map[string]iotago.Mana)
 		for aliasAccount := range epochActions {
-			reward, _, _, err := t.Instance.DelegatorReward(t.Account(aliasAccount, false), 1, epoch, epoch)
+			reward, _, _, err := t.Instance.DelegatorReward(t.Account(aliasAccount, false), 1, epoch, epoch, epoch)
 			require.NoError(t.T, err)
 			delegatorRewardPerAccount[epoch][aliasAccount] = reward
 		}
 		for aliasAccount := range epochActions {
-			reward, _, _, err := t.Instance.ValidatorReward(t.Account(aliasAccount, true), 1, epoch, epoch)
+			reward, _, _, err := t.Instance.ValidatorReward(t.Account(aliasAccount, true),
+				&iotago.StakingFeature{
+					StakedAmount: 1,
+					StartEpoch:   epoch,
+					EndEpoch:     epoch,
+				},
+				epoch)
 			require.NoError(t.T, err)
 			validatorRewardPerAccount[epoch][aliasAccount] = reward
 		}
@@ -334,12 +355,22 @@ func (t *TestSuite) calculateExpectedRewards(epochsCount int, epochActions map[s
 }
 
 func (t *TestSuite) AssertValidatorRewardGreaterThan(alias1 string, alias2 string, epoch iotago.EpochIndex, actions map[string]*EpochActions) {
+	mockStakingFeature1 := &iotago.StakingFeature{
+		StakedAmount: actions[alias1].ValidatorStake,
+		StartEpoch:   epoch,
+		EndEpoch:     epoch,
+	}
+	mockStakingFeature2 := &iotago.StakingFeature{
+		StakedAmount: actions[alias2].ValidatorStake,
+		StartEpoch:   epoch,
+		EndEpoch:     epoch,
+	}
 	accID1 := t.Account(alias1, false)
-	actualValidatorReward1, _, _, err := t.Instance.ValidatorReward(accID1, actions[alias1].ValidatorStake, epoch, epoch)
+	actualValidatorReward1, _, _, err := t.Instance.ValidatorReward(accID1, mockStakingFeature1, epoch)
 	require.NoError(t.T, err)
 
 	accID2 := t.Account(alias2, false)
-	actualValidatorReward2, _, _, err := t.Instance.ValidatorReward(accID2, actions[alias2].ValidatorStake, epoch, epoch)
+	actualValidatorReward2, _, _, err := t.Instance.ValidatorReward(accID2, mockStakingFeature2, epoch)
 	require.NoError(t.T, err)
 
 	require.Greater(t.T, actualValidatorReward1, actualValidatorReward2)

--- a/pkg/protocol/sybilprotection/sybilprotectionv1/performance/testsuite_test.go
+++ b/pkg/protocol/sybilprotection/sybilprotectionv1/performance/testsuite_test.go
@@ -164,13 +164,14 @@ func (t *TestSuite) AssertEpochRewards(epoch iotago.EpochIndex, actions map[stri
 		poolRewards := t.poolRewards[epoch][alias].PoolRewards
 		expectedValidatorReward := t.validatorReward(alias, epoch, t.epochStats[epoch].ProfitMargin, uint64(poolRewards), uint64(action.ValidatorStake), uint64(action.PoolStake), uint64(action.FixedCost), action)
 
-		mockStakingFeature := &iotago.StakingFeature{
-			StakedAmount: actions[alias].ValidatorStake,
-			StartEpoch:   epoch,
-			EndEpoch:     epoch,
-		}
 		accountID := t.Account(alias, true)
-		actualValidatorReward, _, _, err := t.Instance.ValidatorReward(accountID, mockStakingFeature, epoch)
+		actualValidatorReward, _, _, err := t.Instance.ValidatorReward(accountID,
+			&iotago.StakingFeature{
+				StakedAmount: actions[alias].ValidatorStake,
+				StartEpoch:   epoch,
+				EndEpoch:     epoch,
+			},
+			epoch)
 		require.NoError(t.T, err)
 		require.Equal(t.T, expectedValidatorReward, actualValidatorReward)
 
@@ -185,13 +186,14 @@ func (t *TestSuite) AssertEpochRewards(epoch iotago.EpochIndex, actions map[stri
 }
 
 func (t *TestSuite) AssertNoReward(alias string, epoch iotago.EpochIndex, actions map[string]*EpochActions) {
-	mockStakingFeature := &iotago.StakingFeature{
-		StakedAmount: actions[alias].ValidatorStake,
-		StartEpoch:   epoch,
-		EndEpoch:     epoch,
-	}
 	accID := t.Account(alias, false)
-	actualValidatorReward, _, _, err := t.Instance.ValidatorReward(accID, mockStakingFeature, epoch)
+	actualValidatorReward, _, _, err := t.Instance.ValidatorReward(accID,
+		&iotago.StakingFeature{
+			StakedAmount: actions[alias].ValidatorStake,
+			StartEpoch:   epoch,
+			EndEpoch:     epoch,
+		},
+		epoch)
 	require.NoError(t.T, err)
 	require.Equal(t.T, iotago.Mana(0), actualValidatorReward)
 	action, exists := actions[alias]
@@ -204,13 +206,14 @@ func (t *TestSuite) AssertNoReward(alias string, epoch iotago.EpochIndex, action
 }
 
 func (t *TestSuite) AssertRewardForDelegatorsOnly(alias string, epoch iotago.EpochIndex, actions map[string]*EpochActions) {
-	mockStakingFeature := &iotago.StakingFeature{
-		StakedAmount: actions[alias].ValidatorStake,
-		StartEpoch:   epoch,
-		EndEpoch:     epoch,
-	}
 	accID := t.Account(alias, false)
-	actualValidatorReward, _, _, err := t.Instance.ValidatorReward(accID, mockStakingFeature, epoch)
+	actualValidatorReward, _, _, err := t.Instance.ValidatorReward(accID,
+		&iotago.StakingFeature{
+			StakedAmount: actions[alias].ValidatorStake,
+			StartEpoch:   epoch,
+			EndEpoch:     epoch,
+		},
+		epoch)
 	require.NoError(t.T, err)
 	require.Equal(t.T, iotago.Mana(0), actualValidatorReward)
 	action, exists := actions[alias]
@@ -355,22 +358,24 @@ func (t *TestSuite) calculateExpectedRewards(epochsCount int, epochActions map[s
 }
 
 func (t *TestSuite) AssertValidatorRewardGreaterThan(alias1 string, alias2 string, epoch iotago.EpochIndex, actions map[string]*EpochActions) {
-	mockStakingFeature1 := &iotago.StakingFeature{
-		StakedAmount: actions[alias1].ValidatorStake,
-		StartEpoch:   epoch,
-		EndEpoch:     epoch,
-	}
-	mockStakingFeature2 := &iotago.StakingFeature{
-		StakedAmount: actions[alias2].ValidatorStake,
-		StartEpoch:   epoch,
-		EndEpoch:     epoch,
-	}
 	accID1 := t.Account(alias1, false)
-	actualValidatorReward1, _, _, err := t.Instance.ValidatorReward(accID1, mockStakingFeature1, epoch)
+	actualValidatorReward1, _, _, err := t.Instance.ValidatorReward(accID1,
+		&iotago.StakingFeature{
+			StakedAmount: actions[alias1].ValidatorStake,
+			StartEpoch:   epoch,
+			EndEpoch:     epoch,
+		},
+		epoch)
 	require.NoError(t.T, err)
 
 	accID2 := t.Account(alias2, false)
-	actualValidatorReward2, _, _, err := t.Instance.ValidatorReward(accID2, mockStakingFeature2, epoch)
+	actualValidatorReward2, _, _, err := t.Instance.ValidatorReward(accID2,
+		&iotago.StakingFeature{
+			StakedAmount: actions[alias2].ValidatorStake,
+			StartEpoch:   epoch,
+			EndEpoch:     epoch,
+		},
+		epoch)
 	require.NoError(t.T, err)
 
 	require.Greater(t.T, actualValidatorReward1, actualValidatorReward2)

--- a/pkg/protocol/sybilprotection/sybilprotectionv1/sybilprotection.go
+++ b/pkg/protocol/sybilprotection/sybilprotectionv1/sybilprotection.go
@@ -246,12 +246,12 @@ func (o *SybilProtection) SeatManager() seatmanager.SeatManager {
 	return o.seatManager
 }
 
-func (o *SybilProtection) ValidatorReward(validatorID iotago.AccountID, stakeAmount iotago.BaseToken, epochStart iotago.EpochIndex, epochEnd iotago.EpochIndex) (validatorReward iotago.Mana, actualEpochStart iotago.EpochIndex, actualEpochEnd iotago.EpochIndex, err error) {
-	return o.performanceTracker.ValidatorReward(validatorID, stakeAmount, epochStart, epochEnd)
+func (o *SybilProtection) ValidatorReward(validatorID iotago.AccountID, stakingFeature *iotago.StakingFeature, claimingEpoch iotago.EpochIndex) (validatorReward iotago.Mana, firstRewardEpoch iotago.EpochIndex, lastRewardEpoch iotago.EpochIndex, err error) {
+	return o.performanceTracker.ValidatorReward(validatorID, stakingFeature, claimingEpoch)
 }
 
-func (o *SybilProtection) DelegatorReward(validatorID iotago.AccountID, delegatedAmount iotago.BaseToken, epochStart iotago.EpochIndex, epochEnd iotago.EpochIndex) (delegatorsReward iotago.Mana, actualEpochStart iotago.EpochIndex, actualEpochEnd iotago.EpochIndex, err error) {
-	return o.performanceTracker.DelegatorReward(validatorID, delegatedAmount, epochStart, epochEnd)
+func (o *SybilProtection) DelegatorReward(validatorID iotago.AccountID, delegatedAmount iotago.BaseToken, epochStart iotago.EpochIndex, epochEnd iotago.EpochIndex, claimingEpoch iotago.EpochIndex) (delegatorReward iotago.Mana, firstRewardEpoch iotago.EpochIndex, lastRewardEpoch iotago.EpochIndex, err error) {
+	return o.performanceTracker.DelegatorReward(validatorID, delegatedAmount, epochStart, epochEnd, claimingEpoch)
 }
 
 func (o *SybilProtection) Import(reader io.ReadSeeker) error {


### PR DESCRIPTION
Fix decay not being applied until "current epoch" in reward calculation by adding a `claimingEpoch` parameter to the validator and delegator reward functions. Previously the decay was only applied until either the end epoch of the staking/delegation, or the last applied epoch. In a scenario where the validation or delegation is in the past the decay would only be applied on the rewards up to the end epoch, which would be too short.