### PR TITLE
Calculate Validator Rewards starting from start epoch + 1

### DIFF
--- a/pkg/model/block.go
+++ b/pkg/model/block.go
@@ -146,7 +146,6 @@ func (blk *Block) WorkScore() iotago.WorkScore {
 		return workScore
 	}
 
-	// else this is a validator block and should have workScore Zero
-	// TODO: deal with validator blocks with issue #236
+	// Otherwise this is a validation block and should have work score zero.
 	return iotago.WorkScore(0)
 }

--- a/pkg/model/validator_performance.go
+++ b/pkg/model/validator_performance.go
@@ -8,9 +8,9 @@ import (
 )
 
 type ValidatorPerformance struct {
-	// works if ValidatorBlocksPerSlot is less than 32 because we use it as bit vector
+	// works if ValidationBlocksPerSlot is less than 32 because we use it as bit vector
 	SlotActivityVector uint32
-	// can be uint8 because max count per slot is maximally ValidatorBlocksPerSlot + 1
+	// can be uint8 because max count per slot is maximally ValidationBlocksPerSlot + 1
 	BlocksIssuedCount              uint8
 	HighestSupportedVersionAndHash VersionAndHash
 }

--- a/pkg/protocol/engine/accounts/accountsledger/manager.go
+++ b/pkg/protocol/engine/accounts/accountsledger/manager.go
@@ -83,7 +83,7 @@ func (m *Manager) SetLatestCommittedSlot(slot iotago.SlotIndex) {
 	m.latestCommittedSlot = slot
 }
 
-// TrackBlock adds the block to the blockBurns set to deduct the burn from credits upon slot commitment and updates latest supported version of a validator block.
+// TrackBlock adds the block to the blockBurns set to deduct the burn from credits upon slot commitment and updates latest supported version of a validation block.
 func (m *Manager) TrackBlock(block *blocks.Block) {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()

--- a/pkg/protocol/engine/attestation/slotattestation/manager.go
+++ b/pkg/protocol/engine/attestation/slotattestation/manager.go
@@ -146,7 +146,7 @@ func (m *Manager) GetMap(slot iotago.SlotIndex) (ads.Map[iotago.Identifier, iota
 
 // AddAttestationFromValidationBlock adds an attestation from a block to the future attestations (beyond the attestation window).
 func (m *Manager) AddAttestationFromValidationBlock(block *blocks.Block) error {
-	// Only track validator blocks.
+	// Only track validation blocks.
 	if _, isValidationBlock := block.ValidationBlock(); !isValidationBlock {
 		return nil
 	}

--- a/pkg/protocol/sybilprotection/sybilprotectionv1/performance/performance.go
+++ b/pkg/protocol/sybilprotection/sybilprotectionv1/performance/performance.go
@@ -71,7 +71,7 @@ func (t *Tracker) TrackValidationBlock(block *blocks.Block) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
-	validatorBlock, isValidationBlock := block.ValidationBlock()
+	validationBlock, isValidationBlock := block.ValidationBlock()
 	if !isValidationBlock {
 		return
 	}
@@ -86,7 +86,7 @@ func (t *Tracker) TrackValidationBlock(block *blocks.Block) {
 	}
 
 	if isCommitteeMember {
-		t.trackCommitteeMemberPerformance(validatorBlock, block)
+		t.trackCommitteeMemberPerformance(validationBlock, block)
 	}
 }
 
@@ -349,7 +349,7 @@ func (t *Tracker) trackCommitteeMemberPerformance(validationBlock *iotago.Valida
 
 	apiForSlot := t.apiProvider.APIForSlot(block.ID().Slot())
 
-	// we restrict the number up to ValidatorBlocksPerSlot + 1 to know later if the validator issued more blocks than allowed and be able to punish for it
+	// we restrict the number up to ValidationBlocksPerSlot + 1 to know later if the validator issued more blocks than allowed and be able to punish for it
 	// also it can fint into uint8
 	if validatorPerformance.BlocksIssuedCount < apiForSlot.ProtocolParameters().ValidationBlocksPerSlot()+1 {
 		validatorPerformance.BlocksIssuedCount++
@@ -365,7 +365,7 @@ func (t *Tracker) trackCommitteeMemberPerformance(validationBlock *iotago.Valida
 	}
 }
 
-// subslotIndex returns the index for timestamp corresponding to subslot created dividing slot on validatorBlocksPerSlot equal parts.
+// subslotIndex returns the index for timestamp corresponding to subslot created dividing slot on validationBlocksPerSlot equal parts.
 func (t *Tracker) subslotIndex(slot iotago.SlotIndex, issuingTime time.Time) int {
 	epochAPI := t.apiProvider.APIForEpoch(t.latestAppliedEpoch)
 	valBlocksNum := epochAPI.ProtocolParameters().ValidationBlocksPerSlot()

--- a/pkg/protocol/sybilprotection/sybilprotectionv1/performance/performance.go
+++ b/pkg/protocol/sybilprotection/sybilprotectionv1/performance/performance.go
@@ -339,18 +339,19 @@ func (t *Tracker) trackCommitteeMemberPerformance(validationBlock *iotago.Valida
 		return
 	}
 
-	// key not found
+	// No validator performance for this slot yet.
 	if !exists {
 		validatorPerformance = model.NewValidatorPerformance()
 	}
 
-	// set a bit at subslotIndex to 1 to indicate activity in that subslot
+	// Set a bit at subslotIndex to 1 to indicate activity in that subslot.
 	validatorPerformance.SlotActivityVector = validatorPerformance.SlotActivityVector | (1 << t.subslotIndex(block.ID().Slot(), block.ProtocolBlock().Header.IssuingTime))
 
 	apiForSlot := t.apiProvider.APIForSlot(block.ID().Slot())
 
-	// we restrict the number up to ValidationBlocksPerSlot + 1 to know later if the validator issued more blocks than allowed and be able to punish for it
-	// also it can fint into uint8
+	// We restrict the number up to ValidationBlocksPerSlot + 1 to know later if the validator issued
+	// more blocks than allowed and be able to punish for it.
+	// Also it can fit into uint8.
 	if validatorPerformance.BlocksIssuedCount < apiForSlot.ProtocolParameters().ValidationBlocksPerSlot()+1 {
 		validatorPerformance.BlocksIssuedCount++
 	}

--- a/pkg/protocol/sybilprotection/sybilprotectionv1/performance/rewards.go
+++ b/pkg/protocol/sybilprotection/sybilprotectionv1/performance/rewards.go
@@ -27,8 +27,12 @@ func (t *Tracker) ValidatorReward(validatorID iotago.AccountID, stakingFeature *
 
 	validatorReward = 0
 	stakedAmount := stakingFeature.StakedAmount
-	// The earliest rewards can be in the epoch for which a validator could have been selected, which is start epoch + 1.
-	firstRewardEpoch = stakingFeature.StartEpoch + 1
+	firstRewardEpoch = stakingFeature.StartEpoch
+	// Start Epoch = 0 is unmodified as a special case for the initial validators that bootstrap the network to get their rewards.
+	// Otherwise, the earliest rewards can be in the epoch for which a validator could have been selected, which is start epoch + 1.
+	if firstRewardEpoch != 0 {
+		firstRewardEpoch = stakingFeature.StartEpoch + 1
+	}
 	lastRewardEpoch = stakingFeature.EndEpoch
 
 	// Limit reward fetching only to committed epochs.

--- a/pkg/protocol/sybilprotection/sybilprotectionv1/performance/rewards.go
+++ b/pkg/protocol/sybilprotection/sybilprotectionv1/performance/rewards.go
@@ -27,7 +27,8 @@ func (t *Tracker) ValidatorReward(validatorID iotago.AccountID, stakingFeature *
 
 	validatorReward = 0
 	stakedAmount := stakingFeature.StakedAmount
-	firstRewardEpoch = stakingFeature.StartEpoch
+	// The earliest rewards can be in the epoch for which a validator could have been selected, which is start epoch + 1.
+	firstRewardEpoch = stakingFeature.StartEpoch + 1
 	lastRewardEpoch = stakingFeature.EndEpoch
 
 	// Limit reward fetching only to committed epochs.

--- a/pkg/protocol/sybilprotection/sybilprotectionv1/performance/testsuite_test.go
+++ b/pkg/protocol/sybilprotection/sybilprotectionv1/performance/testsuite_test.go
@@ -170,8 +170,9 @@ func (t *TestSuite) AssertEpochRewards(epoch iotago.EpochIndex, actions map[stri
 		actualValidatorReward, _, _, err := t.Instance.ValidatorReward(accountID,
 			&iotago.StakingFeature{
 				StakedAmount: actions[alias].ValidatorStake,
-				StartEpoch:   epoch,
-				EndEpoch:     epoch,
+				// Start Epoch of the Validator would have been before `epoch`.
+				StartEpoch: epoch - 1,
+				EndEpoch:   epoch,
 			},
 			epoch)
 		require.NoError(t.T, err)
@@ -364,8 +365,9 @@ func (t *TestSuite) AssertValidatorRewardGreaterThan(alias1 string, alias2 strin
 	actualValidatorReward1, _, _, err := t.Instance.ValidatorReward(accID1,
 		&iotago.StakingFeature{
 			StakedAmount: actions[alias1].ValidatorStake,
-			StartEpoch:   epoch,
-			EndEpoch:     epoch,
+			// Start Epoch of the Validator would have been before `epoch`.
+			StartEpoch: epoch - 1,
+			EndEpoch:   epoch,
 		},
 		epoch)
 	require.NoError(t.T, err)
@@ -374,8 +376,9 @@ func (t *TestSuite) AssertValidatorRewardGreaterThan(alias1 string, alias2 strin
 	actualValidatorReward2, _, _, err := t.Instance.ValidatorReward(accID2,
 		&iotago.StakingFeature{
 			StakedAmount: actions[alias2].ValidatorStake,
-			StartEpoch:   epoch,
-			EndEpoch:     epoch,
+			// Start Epoch of the Validator would have been before `epoch`.
+			StartEpoch: epoch - 1,
+			EndEpoch:   epoch,
 		},
 		epoch)
 	require.NoError(t.T, err)

--- a/pkg/protocol/sybilprotection/sybilprotectionv1/performance/testsuite_test.go
+++ b/pkg/protocol/sybilprotection/sybilprotectionv1/performance/testsuite_test.go
@@ -392,7 +392,7 @@ type EpochActions struct {
 	ActiveSlotsCount uint64
 	// ValidationBlocksSentPerSlot is the number of validation blocks validator sent per slot.
 	ValidationBlocksSentPerSlot uint64
-	// SlotPerformance is the target slot performance factor, how many subslots were covered by validator blocks.
+	// SlotPerformance is the target slot performance factor, how many subslots were covered by validation blocks.
 	SlotPerformance uint64
 }
 

--- a/pkg/tests/booker_test.go
+++ b/pkg/tests/booker_test.go
@@ -120,7 +120,7 @@ func Test_WeightPropagation(t *testing.T) {
 		ts.AssertBlocksInCachePreAccepted(ts.Blocks("block3-basic", "block4-basic", "block5-basic", "block6-basic"), false, ts.Nodes()...)
 	}
 
-	// Issue validator blocks that are subjectively invalid, but accept the basic blocks.
+	// Issue validation blocks that are subjectively invalid, but accept the basic blocks.
 	// Make sure that the pre-accepted basic blocks do not apply approval weight - the conflicts should remain unresolved.
 	// If basic blocks carry approval or witness weight, then the test will fail.
 	{

--- a/pkg/testsuite/mock/block_params.go
+++ b/pkg/testsuite/mock/block_params.go
@@ -23,7 +23,7 @@ type BasicBlockParams struct {
 	BlockHeader *BlockHeaderParams
 	Payload     iotago.Payload
 }
-type ValidatorBlockParams struct {
+type ValidationBlockParams struct {
 	BlockHeader             *BlockHeaderParams
 	HighestSupportedVersion *iotago.Version
 	ProtocolParametersHash  *iotago.Identifier
@@ -99,8 +99,8 @@ func WithSkipReferenceValidation(skipReferenceValidation bool) func(builder *Blo
 	}
 }
 
-func WithValidationBlockHeaderOptions(opts ...options.Option[BlockHeaderParams]) func(builder *ValidatorBlockParams) {
-	return func(builder *ValidatorBlockParams) {
+func WithValidationBlockHeaderOptions(opts ...options.Option[BlockHeaderParams]) func(builder *ValidationBlockParams) {
+	return func(builder *ValidationBlockParams) {
 		builder.BlockHeader = options.Apply(&BlockHeaderParams{}, opts)
 	}
 }
@@ -117,14 +117,14 @@ func WithPayload(payload iotago.Payload) func(builder *BasicBlockParams) {
 	}
 }
 
-func WithHighestSupportedVersion(highestSupportedVersion iotago.Version) func(builder *ValidatorBlockParams) {
-	return func(builder *ValidatorBlockParams) {
+func WithHighestSupportedVersion(highestSupportedVersion iotago.Version) func(builder *ValidationBlockParams) {
+	return func(builder *ValidationBlockParams) {
 		builder.HighestSupportedVersion = &highestSupportedVersion
 	}
 }
 
-func WithProtocolParametersHash(protocolParametersHash iotago.Identifier) func(builder *ValidatorBlockParams) {
-	return func(builder *ValidatorBlockParams) {
+func WithProtocolParametersHash(protocolParametersHash iotago.Identifier) func(builder *ValidationBlockParams) {
+	return func(builder *ValidationBlockParams) {
 		builder.ProtocolParametersHash = &protocolParametersHash
 	}
 }

--- a/pkg/testsuite/mock/blockissuer.go
+++ b/pkg/testsuite/mock/blockissuer.go
@@ -101,8 +101,8 @@ func (i *BlockIssuer) Shutdown() {
 	i.workerPool.ShutdownComplete.Wait()
 }
 
-func (i *BlockIssuer) CreateValidationBlock(ctx context.Context, alias string, issuerAccount wallet.Account, node *Node, opts ...options.Option[ValidatorBlockParams]) (*blocks.Block, error) {
-	blockParams := options.Apply(&ValidatorBlockParams{}, opts)
+func (i *BlockIssuer) CreateValidationBlock(ctx context.Context, alias string, issuerAccount wallet.Account, node *Node, opts ...options.Option[ValidationBlockParams]) (*blocks.Block, error) {
+	blockParams := options.Apply(&ValidationBlockParams{}, opts)
 
 	if blockParams.BlockHeader.IssuingTime == nil {
 		issuingTime := time.Now().UTC()
@@ -189,7 +189,7 @@ func (i *BlockIssuer) CreateValidationBlock(ctx context.Context, alias string, i
 	return blocks.NewBlock(modelBlock), nil
 }
 
-func (i *BlockIssuer) IssueValidationBlock(ctx context.Context, alias string, node *Node, opts ...options.Option[ValidatorBlockParams]) *blocks.Block {
+func (i *BlockIssuer) IssueValidationBlock(ctx context.Context, alias string, node *Node, opts ...options.Option[ValidationBlockParams]) *blocks.Block {
 	block, err := i.CreateValidationBlock(ctx, alias, wallet.NewEd25519Account(i.AccountID, i.privateKey), node, opts...)
 	require.NoError(i.Testing, err)
 

--- a/pkg/testsuite/mock/node.go
+++ b/pkg/testsuite/mock/node.go
@@ -94,11 +94,11 @@ func NewNode(t *testing.T, net *Network, partition string, name string, validato
 	peerID := lo.PanicOnErr(peer.IDFromPrivateKey(lo.PanicOnErr(p2pcrypto.UnmarshalEd25519PrivateKey(priv))))
 	RegisterIDAlias(peerID, name)
 
-	var validatorBlockIssuer *BlockIssuer
+	var validationBlockIssuer *BlockIssuer
 	if validator {
-		validatorBlockIssuer = NewBlockIssuer(t, name, keyManager, accountID, validator)
+		validationBlockIssuer = NewBlockIssuer(t, name, keyManager, accountID, validator)
 	} else {
-		validatorBlockIssuer = nil
+		validationBlockIssuer = nil
 	}
 
 	return &Node{
@@ -106,7 +106,7 @@ func NewNode(t *testing.T, net *Network, partition string, name string, validato
 
 		Name: name,
 
-		Validator:  validatorBlockIssuer,
+		Validator:  validationBlockIssuer,
 		KeyManager: keyManager,
 
 		PeerID: peerID,
@@ -543,7 +543,7 @@ func (n *Node) AttachedBlocks() []*blocks.Block {
 	return n.attachedBlocks
 }
 
-func (n *Node) IssueValidationBlock(ctx context.Context, alias string, opts ...options.Option[ValidatorBlockParams]) *blocks.Block {
+func (n *Node) IssueValidationBlock(ctx context.Context, alias string, opts ...options.Option[ValidationBlockParams]) *blocks.Block {
 	if n.Validator == nil {
 		panic("node is not a validator")
 	}

--- a/pkg/testsuite/testsuite.go
+++ b/pkg/testsuite/testsuite.go
@@ -554,7 +554,7 @@ func (t *TestSuite) Validators() []*mock.Node {
 	return validators
 }
 
-// BlockIssersForNodes returns a map of block issuers for each node. If the node is a validator, its block issuer is the validator block issuer. Else, it is the block issuer for the test suite.
+// BlockIssersForNodes returns a map of block issuers for each node. If the node is a validator, its block issuer is the validation block issuer. Else, it is the block issuer for the test suite.
 func (t *TestSuite) BlockIssuersForNodes(nodes []*mock.Node) []*mock.BlockIssuer {
 	blockIssuers := make([]*mock.BlockIssuer, 0)
 	for _, node := range nodes {

--- a/pkg/testsuite/testsuite_issue_blocks.go
+++ b/pkg/testsuite/testsuite_issue_blocks.go
@@ -92,7 +92,7 @@ func (t *TestSuite) IssueExistingBlock(blockName string, wallet *mock.Wallet) {
 	require.NoError(t.Testing, wallet.BlockIssuer.IssueBlock(block.ModelBlock(), wallet.Node))
 }
 
-func (t *TestSuite) IssueValidationBlockWithOptions(blockName string, node *mock.Node, blockOpts ...options.Option[mock.ValidatorBlockParams]) *blocks.Block {
+func (t *TestSuite) IssueValidationBlockWithOptions(blockName string, node *mock.Node, blockOpts ...options.Option[mock.ValidationBlockParams]) *blocks.Block {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
@@ -149,7 +149,7 @@ func (t *TestSuite) issueBlockRow(prefix string, row int, parentsPrefix string, 
 		issuingTime := timeProvider.SlotStartTime(t.currentSlot).Add(time.Duration(t.uniqueBlockTimeCounter.Add(1)))
 
 		var b *blocks.Block
-		// Only issue validator blocks if account has staking feature and is part of committee.
+		// Only issue validation blocks if account has staking feature and is part of committee.
 		if node.Validator != nil && lo.Return1(node.Protocol.Engines.Main.Get().SybilProtection.SeatManager().CommitteeInSlot(t.currentSlot)).HasAccount(node.Validator.AccountID) {
 			blockHeaderOptions := append(issuingOptionsCopy[node.Name], mock.WithIssuingTime(issuingTime))
 			t.assertParentsCommitmentExistFromBlockOptions(blockHeaderOptions, node)


### PR DESCRIPTION
Calculate Validator Rewards starting from start epoch + 1 as described in TIP-40. Essentially, the rationale to increase it is that the `Start Epoch` of a Staking Feature is the epoch in which staking started, but the first time this validator can be selected is `Start Epoch + 1`, hence the earliest rewards can be earned in that epoch.

Also fixes "validator block" -> "validation block" typos.