### PR TITLE
added generating snapshot from yml file

### DIFF
--- a/tools/genesis-snapshot/main.go
+++ b/tools/genesis-snapshot/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"strings"
 
 	"github.com/mr-tron/base58"
 	flag "github.com/spf13/pflag"
@@ -16,13 +17,21 @@ import (
 func main() {
 	parsedOpts, configSelected := parseFlags()
 	opts := presets.Base
-	switch configSelected {
-	case "docker":
-		opts = append(opts, presets.Docker...)
-	case "feature":
-		opts = append(opts, presets.Feature...)
-	default:
-		configSelected = "default"
+	if strings.Contains(configSelected, ".yml") {
+		if yamlOpts, err := presets.GenerateFromYaml(configSelected); err != nil {
+			panic(err)
+		} else {
+			opts = append(opts, yamlOpts...)
+		}
+	} else {
+		switch configSelected {
+		case "docker":
+			opts = append(opts, presets.Docker...)
+		case "feature":
+			opts = append(opts, presets.Feature...)
+		default:
+			configSelected = "default"
+		}
 	}
 	opts = append(opts, parsedOpts...)
 	info := snapshotcreator.NewOptions(opts...)

--- a/tools/genesis-snapshot/presets/presets_yaml.go
+++ b/tools/genesis-snapshot/presets/presets_yaml.go
@@ -1,0 +1,108 @@
+package presets
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/crypto/blake2b"
+	"gopkg.in/yaml.v3"
+
+	"github.com/iotaledger/hive.go/crypto/ed25519"
+	"github.com/iotaledger/hive.go/lo"
+	"github.com/iotaledger/hive.go/runtime/options"
+	"github.com/iotaledger/iota-core/pkg/testsuite/mock"
+	"github.com/iotaledger/iota-core/pkg/testsuite/snapshotcreator"
+	iotago "github.com/iotaledger/iota.go/v4"
+	"github.com/iotaledger/iota.go/v4/hexutil"
+)
+
+type ValidatorYaml struct {
+	Name      string `yaml:"name"`
+	PublicKey string `yaml:"public-key"`
+}
+
+type BlockIssuerYaml struct {
+	Name      string `yaml:"name"`
+	PublicKey string `yaml:"public-key"`
+}
+
+type BasicOutputYaml struct {
+	Address string `yaml:"address"`
+	Amount  uint64 `yaml:"amount"`
+	Mana    uint64 `yaml:"mana"`
+}
+
+type ConfigYaml struct {
+	Name     string `yaml:"name"`
+	FilePath string `yaml:"filepath"`
+
+	Validators   []ValidatorYaml   `yaml:"validators"`
+	BlockIssuers []BlockIssuerYaml `yaml:"block-issuers"`
+	BasicOutputs []BasicOutputYaml `yaml:"basic-outputs"`
+}
+
+func GenerateFromYaml(hostsFile string) ([]options.Option[snapshotcreator.Options], error) {
+	yamlFile, err := os.ReadFile(hostsFile)
+	if err != nil {
+		return nil, err
+	}
+	var configYaml ConfigYaml
+	err = yaml.Unmarshal(yamlFile, &configYaml)
+	if err != nil {
+		return nil, err
+	}
+
+	var accounts []snapshotcreator.AccountDetails
+	for _, validator := range configYaml.Validators {
+		pubkey := validator.PublicKey
+		fmt.Printf("adding validator %s with publicKey %s\n", validator.Name, pubkey)
+		account := snapshotcreator.AccountDetails{
+			AccountID:            blake2b.Sum256(lo.PanicOnErr(hexutil.DecodeHex(pubkey))),
+			Address:              iotago.Ed25519AddressFromPubKey(lo.PanicOnErr(hexutil.DecodeHex(pubkey))),
+			Amount:               mock.MinValidatorAccountAmount(protocolParamsDocker),
+			IssuerKey:            iotago.Ed25519PublicKeyBlockIssuerKeyFromPublicKey(ed25519.PublicKey(lo.PanicOnErr(hexutil.DecodeHex(pubkey)))),
+			ExpirySlot:           iotago.MaxSlotIndex,
+			BlockIssuanceCredits: iotago.MaxBlockIssuanceCredits / 4,
+			StakingEndEpoch:      iotago.MaxEpochIndex,
+			FixedCost:            1,
+			StakedAmount:         mock.MinValidatorAccountAmount(protocolParamsDocker),
+			Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protocolParamsDocker)),
+		}
+		accounts = append(accounts, account)
+	}
+
+	for _, blockIssuer := range configYaml.BlockIssuers {
+		pubkey := blockIssuer.PublicKey
+		fmt.Printf("adding blockissueer %s with publicKey %s\n", blockIssuer.Name, pubkey)
+		account := snapshotcreator.AccountDetails{
+			AccountID:            blake2b.Sum256(lo.PanicOnErr(hexutil.DecodeHex(pubkey))),
+			Address:              iotago.Ed25519AddressFromPubKey(lo.PanicOnErr(hexutil.DecodeHex(pubkey))),
+			Amount:               mock.MinValidatorAccountAmount(protocolParamsDocker),
+			IssuerKey:            iotago.Ed25519PublicKeyBlockIssuerKeyFromPublicKey(ed25519.PublicKey(lo.PanicOnErr(hexutil.DecodeHex(pubkey)))),
+			ExpirySlot:           iotago.MaxSlotIndex,
+			BlockIssuanceCredits: iotago.MaxBlockIssuanceCredits / 4,
+			Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protocolParamsDocker)),
+		}
+		accounts = append(accounts, account)
+	}
+
+	var basicOutputs []snapshotcreator.BasicOutputDetails
+	for _, basicOutput := range configYaml.BasicOutputs {
+		address := lo.Return2(iotago.ParseBech32(basicOutput.Address))
+		amount := basicOutput.Amount
+		mana := basicOutput.Mana
+		fmt.Printf("adding basicOutput for %s with amount %d and mana %d\n", address, amount, mana)
+		basicOutputs = append(basicOutputs, snapshotcreator.BasicOutputDetails{
+			Address: address,
+			Amount:  iotago.BaseToken(amount),
+			Mana:    iotago.Mana(mana),
+		})
+	}
+
+	return []options.Option[snapshotcreator.Options]{
+		snapshotcreator.WithFilePath(configYaml.FilePath),
+		snapshotcreator.WithProtocolParameters(protocolParamsDocker),
+		snapshotcreator.WithAccounts(accounts...),
+		snapshotcreator.WithBasicOutputs(basicOutputs...),
+	}, nil
+}


### PR DESCRIPTION
If the `--config` parameter contains the string `.yml` it generates the snapshot from a `yaml` file like this:

```yaml
name: docker
filepath: docker-network.snapshot

validators:
  #Ed25519 Public Key:   293dc170d9a59474e6d81cfba7f7d924c09b25d7166bcfba606e53114d0a758b
  #Ed25519 Address:      rms1qzg8cqhfxqhq7pt37y8cs4v5u4kcc48lquy2k73ehsdhf5ukhya3ytgk0ny
  #Account Address:      rms1pzg8cqhfxqhq7pt37y8cs4v5u4kcc48lquy2k73ehsdhf5ukhya3y5rx2w6
  #Restricted Address:   rms1xqqfqlqzayczurc9w8cslzz4jnjkmrz5lurs32m68x7pkaxnj6unkyspqg8mulpm, Capabilities: mana
  - name: "node-01-validator"
    public-key: '0x293dc170d9a59474e6d81cfba7f7d924c09b25d7166bcfba606e53114d0a758b'

  #Ed25519 Public Key:   05c1de274451db8de8182d64c6ee0dca3ae0c9077e0b4330c976976171d79064
  #Ed25519 Address:      rms1qqm4xk8e9ny5w5rxjkvtp249tfhlwvcshyr3pc0665jvp7g3hc875flpz2p
  #Account Address:      rms1pqm4xk8e9ny5w5rxjkvtp249tfhlwvcshyr3pc0665jvp7g3hc875k538hl
  #Restricted Address:   rms1xqqrw56clykvj36sv62e3v9254dxlaenzzuswy8plt2jfs8ezxlql6spqgkulf7u, Capabilities: mana
  - name: "node-02-validator"
    public-key: '0x05c1de274451db8de8182d64c6ee0dca3ae0c9077e0b4330c976976171d79064'

  #Ed25519 Public Key:   1e4b21eb51dcddf65c20db1065e1f1514658b23a3ddbf48d30c0efc926a9a648
  #Ed25519 Address:      rms1qp4wuuz0y42caz48vv876qfpmffswsvg40zz8v79sy8cp0jfxm4kuvz0a44
  #Account Address:      rms1pp4wuuz0y42caz48vv876qfpmffswsvg40zz8v79sy8cp0jfxm4kunflcgt
  #Restricted Address:   rms1xqqx4mnsfuj4tr525a3slmgpy8d9xp6p3z4ugganckqslq97fymwkmspqgnzrkjq, Capabilities: mana
  - name: "node-03-validator"
    public-key: '0x1e4b21eb51dcddf65c20db1065e1f1514658b23a3ddbf48d30c0efc926a9a648'

block-issuers:
  #Ed25519 Private Key:  432c624ca3260f910df35008d5c740593b222f1e196e6cdb8cd1ad080f0d4e33997be92a22b1933f36e26fba5f721756f95811d6b4ae21564197c2bfa4f28270
  #Ed25519 Public Key:   997be92a22b1933f36e26fba5f721756f95811d6b4ae21564197c2bfa4f28270
  #Ed25519 Address:      rms1qrkursay9fs2qjmfctamd6yxg9x8r3ry47786x0mvwek4qr9xd9d583cnpd
  #Account Address:      rms1prkursay9fs2qjmfctamd6yxg9x8r3ry47786x0mvwek4qr9xd9d5c6gkun
  #Restricted Address:   rms1xqqwmswr5s4xpgztd8p0hdhgseq5cuwyvjhmclgeld3mx65qv5e54kspqgda0nrn, Capabilities: mana
  - name: "inx-blockissuer"
    public-key: '0x997be92a22b1933f36e26fba5f721756f95811d6b4ae21564197c2bfa4f28270'

basic-outputs:
  #inx-faucet
  #Ed25519 Private Key:  de52b9964dda96564e9fab362ab16c2669c715c6a2a853bece8a25fc58c599755b938327ea463e0c323c0fd44f6fc1843ed94daecc6909c6043d06b7152e4737
  #Ed25519 Public Key:   5b938327ea463e0c323c0fd44f6fc1843ed94daecc6909c6043d06b7152e4737
  #Ed25519 Address:      rms1qqhkf7w30xv375z59vq7qd86qsa3j4qrsadcval04uvkkswg3qpaqf4hga2
  #Restricted Address:   rms1xqqz7e8e69uej86s2s4srcp5lgzrkx25qwr4hpnha7h3j66pezyq85qpqg55v3ur, Capabilities: mana
  - address: rms1xqqz7e8e69uej86s2s4srcp5lgzrkx25qwr4hpnha7h3j66pezyq85qpqg55v3ur
    amount: 1000000000000000
    mana: 10000000
```