### PR TITLE
Fix docker network test framework

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/iotaledger/hive.go/stringify v0.0.0-20231219105941-542b1b724494
 	github.com/iotaledger/inx-app v1.0.0-rc.3.0.20240110125343-5c50e43b71fa
 	github.com/iotaledger/inx/go v1.0.0-rc.2.0.20240110120225-05a4544ca1dd
+	github.com/iotaledger/iota-crypto-demo v0.0.0-20231208171603-786bb32fdb00
 	github.com/iotaledger/iota.go/v4 v4.0.0-20240110093746-74501e609f1c
 	github.com/labstack/echo/v4 v4.11.3
 	github.com/labstack/gommon v0.4.1
@@ -87,7 +88,6 @@ require (
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/iancoleman/orderedmap v0.3.0 // indirect
 	github.com/iotaledger/grocksdb v1.7.5-0.20230220105546-5162e18885c7 // indirect
-	github.com/iotaledger/iota-crypto-demo v0.0.0-20231208171603-786bb32fdb00 // indirect
 	github.com/ipfs/boxo v0.13.1 // indirect
 	github.com/ipfs/go-cid v0.4.1 // indirect
 	github.com/ipfs/go-datastore v0.6.0 // indirect

--- a/tools/docker-network/run.sh
+++ b/tools/docker-network/run.sh
@@ -28,13 +28,16 @@ fi
 echo $DOCKER_BUILD_CONTEXT $DOCKERFILE_PATH
 docker compose build --build-arg WITH_GO_WORK=${WITH_GO_WORK:-0} --build-arg DOCKER_BUILD_CONTEXT=${DOCKER_BUILD_CONTEXT} --build-arg DOCKERFILE_PATH=${DOCKERFILE_PATH}
 
-docker compose pull inx-indexer inx-mqtt inx-blockissuer inx-faucet inx-validator-1
-
 # check exit code of builder
 if [ $? -ne 0 ]; then
   echo "Building failed. Please fix and try again!"
   exit 1
 fi
+
+docker compose pull inx-indexer inx-mqtt inx-blockissuer inx-faucet inx-validator-1
+
+# Remove old snapshot file
+rm *.snapshot
 
 # create snapshot file
 echo "Create snapshot"
@@ -73,4 +76,3 @@ docker compose up
 
 echo "Clean up docker resources"
 docker compose down -v
-rm *.snapshot

--- a/tools/docker-network/tests/README.md
+++ b/tools/docker-network/tests/README.md
@@ -3,24 +3,16 @@
 These tests and the `DockerTestFramework` are using the Docker network and simulate a real network environment with multiple nodes.
 They are therefore fully-fledged integration tests that test the entire node and inx-* connections.
 
-The tests are by default excluded from compilation and tests with `//go:build dockertests`. To run the tests, the `dockertests` build tag must be added when compiling. 
-
-## Prerequisites
-Before running the tests make sure to build the latest image and pull the latest images from Docker Hub.
-
-```bash
-cd tools/docker-network
-docker compose build
-docker compose pull inx-indexer inx-mqtt inx-blockissuer inx-faucet inx-validator-1
-```
+The tests are by default excluded from compilation and tests with `//go:build dockertests`.
+To run the tests, the `dockertests` build tag must be added when compiling or simply use the `run_tests.sh` script. 
 
 ## Running the tests
 To run the tests, simply execute the following command:
 
 ```bash
 # run all tests
-go test ./... -tags rocksdb,dockertests -v -timeout=60m
+./run_tests.sh
 
-# or to run a specific test 
-go test -run=Test_Delegation -tags rocksdb,dockertests -v -timeout=60m
+# or to run a specific tests
+./run_tests.sh Test_Delegation Test_NoCandidacyPayload
 ```

--- a/tools/docker-network/tests/committeerotation_test.go
+++ b/tools/docker-network/tests/committeerotation_test.go
@@ -18,7 +18,7 @@ func Test_SmallerCommittee(t *testing.T) {
 		WithProtocolParametersOptions(
 			iotago.WithTimeProviderOptions(5, time.Now().Unix(), 10, 4),
 			iotago.WithLivenessOptions(10, 10, 2, 4, 8),
-			iotago.WithRewardsOptions(8, 8, 10, 2, 1),
+			iotago.WithRewardsOptions(8, 8, 10, 2, 1, 5),
 			iotago.WithTargetCommitteeSize(4),
 		))
 	defer d.Stop()
@@ -58,7 +58,7 @@ func Test_ReuseDueToNoFinalization(t *testing.T) {
 		WithProtocolParametersOptions(
 			iotago.WithTimeProviderOptions(5, time.Now().Unix(), 10, 4),
 			iotago.WithLivenessOptions(10, 10, 2, 4, 8),
-			iotago.WithRewardsOptions(8, 8, 10, 2, 1),
+			iotago.WithRewardsOptions(8, 8, 10, 2, 1, 5),
 			iotago.WithTargetCommitteeSize(4),
 		))
 	defer d.Stop()
@@ -122,7 +122,7 @@ func Test_NoCandidacyPayload(t *testing.T) {
 		WithProtocolParametersOptions(
 			iotago.WithTimeProviderOptions(5, time.Now().Unix(), 10, 4),
 			iotago.WithLivenessOptions(10, 10, 2, 4, 8),
-			iotago.WithRewardsOptions(8, 8, 10, 2, 1),
+			iotago.WithRewardsOptions(8, 8, 10, 2, 1, 5),
 			iotago.WithTargetCommitteeSize(4),
 		))
 	defer d.Stop()
@@ -169,7 +169,7 @@ func Test_Staking(t *testing.T) {
 		WithProtocolParametersOptions(
 			iotago.WithTimeProviderOptions(5, time.Now().Unix(), 10, 4),
 			iotago.WithLivenessOptions(10, 10, 2, 4, 8),
-			iotago.WithRewardsOptions(8, 8, 10, 2, 1),
+			iotago.WithRewardsOptions(8, 8, 10, 2, 1, 5),
 			iotago.WithTargetCommitteeSize(3),
 		))
 	defer d.Stop()
@@ -196,7 +196,7 @@ func Test_Delegation(t *testing.T) {
 		WithProtocolParametersOptions(
 			iotago.WithTimeProviderOptions(5, time.Now().Unix(), 10, 4),
 			iotago.WithLivenessOptions(10, 10, 2, 4, 8),
-			iotago.WithRewardsOptions(8, 8, 10, 2, 1),
+			iotago.WithRewardsOptions(8, 8, 10, 2, 1, 5),
 			iotago.WithTargetCommitteeSize(3),
 		))
 	defer d.Stop()

--- a/tools/docker-network/tests/run_tests.sh
+++ b/tools/docker-network/tests/run_tests.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+BUILD_TAGS="rocksdb,dockertests"
+TIMEOUT=120m
+
+# Exit script on non-zero command exit status
+set -e
+
+# Change directory to the parent directory of this script
+pushd ../
+
+# Build the docker image with buildkit
+echo "Build iota-core docker image"
+export DOCKER_BUILDKIT=1
+export COMPOSE_DOCKER_CLI_BUILD=1
+export DOCKER_BUILD_CONTEXT="../../"
+export DOCKERFILE_PATH="./Dockerfile.dev"
+
+# Allow docker compose to build and cache an image
+docker compose build --build-arg DOCKER_BUILD_CONTEXT=${DOCKER_BUILD_CONTEXT} --build-arg DOCKERFILE_PATH=${DOCKERFILE_PATH}
+
+# Pull missing images
+docker compose pull inx-indexer inx-mqtt inx-blockissuer inx-faucet inx-validator-1
+
+# Change directory back to the original directory
+popd
+
+# If no arguments were passed, run all tests
+if [ $# -eq 0 ]; then
+    echo "Running all tests..."
+    go test ./... -tags ${BUILD_TAGS} -v -timeout=${TIMEOUT}
+else
+    # Concatenate all test names with a pipe
+    tests=$(printf "|%s" "$@")
+    tests=${tests:1}
+
+    echo "Running tests: $tests..."
+
+    # Run the specific tests
+    go test -run=$tests -tags ${BUILD_TAGS} -v -timeout=${TIMEOUT}
+fi

--- a/tools/genesis-snapshot/go.mod
+++ b/tools/genesis-snapshot/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/mr-tron/base58 v1.2.0
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/crypto v0.17.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -64,6 +65,5 @@ require (
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/blake3 v1.2.1 // indirect
 )


### PR DESCRIPTION
Docker tests broke due to a newly added retention parameter. This PR fixes this.
It also adds a new script to simplify the usage of the docker test framework.

The former docker run script was also fixed. Commands were executed in the wrong order there.