### PR TITLE
Improve passing OnlineCommittee size callback

### DIFF
--- a/pkg/protocol/engine/ledger/ledger/ledger.go
+++ b/pkg/protocol/engine/ledger/ledger/ledger.go
@@ -64,7 +64,9 @@ func NewProvider() module.Provider[*engine.Engine, ledger.Ledger] {
 
 		e.Constructed.OnTrigger(func() {
 			e.Events.Ledger.LinkTo(l.events)
-			l.spendDAG = spenddagv1.New[iotago.TransactionID, mempool.StateID, ledger.BlockVoteRank](l.sybilProtection.SeatManager().OnlineCommittee().Size)
+			l.spendDAG = spenddagv1.New[iotago.TransactionID, mempool.StateID, ledger.BlockVoteRank](func() int {
+				return l.sybilProtection.SeatManager().OnlineCommittee().Size()
+			})
 			e.Events.SpendDAG.LinkTo(l.spendDAG.Events())
 
 			l.setRetainTransactionFailureFunc(e.Retainer.RetainTransactionFailure)
@@ -111,7 +113,9 @@ func New(
 		commitmentLoader: commitmentLoader,
 		sybilProtection:  sybilProtection,
 		errorHandler:     errorHandler,
-		spendDAG:         spenddagv1.New[iotago.TransactionID, mempool.StateID, ledger.BlockVoteRank](sybilProtection.SeatManager().OnlineCommittee().Size),
+		spendDAG: spenddagv1.New[iotago.TransactionID, mempool.StateID, ledger.BlockVoteRank](func() int {
+			return sybilProtection.SeatManager().OnlineCommittee().Size()
+		}),
 	}
 }
 

--- a/pkg/protocol/engine/mempool/v1/inclusion_flags.go
+++ b/pkg/protocol/engine/mempool/v1/inclusion_flags.go
@@ -75,24 +75,24 @@ func (s *inclusionFlags) OnRejected(callback func()) {
 	s.rejected.OnTrigger(callback)
 }
 
-// IsCommitted returns true if the entity was committed.
+// CommittedSlot returns the slot in which the entity is committed and a bool value indicating if the entity was committed.
 func (s *inclusionFlags) CommittedSlot() (slot iotago.SlotIndex, isCommitted bool) {
 	return s.committedSlot.Get(), s.committedSlot.Get() != 0
 }
 
-// OnCommitted registers a callback that gets triggered when the entity gets committed.
+// OnCommittedSlotUpdated registers a callback that gets triggered when the slot in which the entity is committed gets updated..
 func (s *inclusionFlags) OnCommittedSlotUpdated(callback func(slot iotago.SlotIndex)) {
 	s.committedSlot.OnUpdate(func(_ iotago.SlotIndex, newValue iotago.SlotIndex) {
 		callback(newValue)
 	})
 }
 
-// IsOrphaned returns true if the entity was orphaned.
+// OrphanedSlot returns a slot in which the entity has been orphaned and a bool flag indicating whether it was orphaned.
 func (s *inclusionFlags) OrphanedSlot() (slot iotago.SlotIndex, isOrphaned bool) {
 	return s.orphanedSlot.Get(), s.orphanedSlot.Get() != 0
 }
 
-// OnOrphaned registers a callback that gets triggered when the entity gets orphaned.
+// OnOrphanedSlotUpdated registers a callback that gets triggered when the orphaned slot is updated.
 func (s *inclusionFlags) OnOrphanedSlotUpdated(callback func(slot iotago.SlotIndex)) {
 	s.orphanedSlot.OnUpdate(func(_ iotago.SlotIndex, newValue iotago.SlotIndex) {
 		callback(newValue)

--- a/pkg/protocol/engine/tipselection/v1/provider.go
+++ b/pkg/protocol/engine/tipselection/v1/provider.go
@@ -21,7 +21,9 @@ func NewProvider(opts ...options.Option[TipSelection]) module.Provider[*engine.E
 		e.Constructed.OnTrigger(func() {
 			// wait for submodules to be constructed (so all of their properties are available)
 			module.OnAllConstructed(func() {
-				t.Construct(e.TipManager, e.Ledger.SpendDAG(), e.Ledger.MemPool().TransactionMetadata, func() iotago.BlockID { return lo.Return1(e.EvictionState.LatestActiveRootBlock()) }, DynamicLivenessThreshold(e.SybilProtection.SeatManager().OnlineCommittee().Size))
+				t.Construct(e.TipManager, e.Ledger.SpendDAG(), e.Ledger.MemPool().TransactionMetadata, func() iotago.BlockID { return lo.Return1(e.EvictionState.LatestActiveRootBlock()) }, DynamicLivenessThreshold(func() int {
+					return e.SybilProtection.SeatManager().OnlineCommittee().Size()
+				}))
 			}, e.TipManager, e.Ledger, e.SybilProtection)
 		})
 

--- a/pkg/protocol/sybilprotection/seatmanager/seatmanager.go
+++ b/pkg/protocol/sybilprotection/seatmanager/seatmanager.go
@@ -31,9 +31,10 @@ type SeatManager interface {
 	// OnlineCommittee returns the set of online validators that is used to track acceptance.
 	OnlineCommittee() ds.Set[account.SeatIndex]
 
-	// SeatCount returns the number of seats in the SeatManager.
+	// SeatCountInSlot returns the number of seats in the SeatManager for the given slot's epoch.
 	SeatCountInSlot(slot iotago.SlotIndex) int
 
+	// SeatCountInEpoch returns the number of seats in the SeatManager for the given epoch.
 	SeatCountInEpoch(epoch iotago.EpochIndex) int
 
 	// Interface embeds the required methods of the module.Interface.


### PR DESCRIPTION
Previously `.Size` method was passed to some components, which was correct but relied on internal implementation details of ActivityTracker. 
To avoid potential problems in the future a separate callback is created that always uses the current SybilProtection and OnlineCommittee instance which is more robust to internal changes to the implementation.

Also, fixed some comments above methods.