### PR TITLE
Cleanup usage of SyncManager and Settings across codebase.

### DIFF
--- a/components/debugapi/node.go
+++ b/components/debugapi/node.go
@@ -10,7 +10,7 @@ import (
 //nolint:unparam // we have no error case right now
 func validatorsSummary() (*ValidatorsSummaryResponse, error) {
 	seatManager := deps.Protocol.Engines.Main.Get().SybilProtection.SeatManager()
-	latestSlotIndex := deps.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Slot()
+	latestSlotIndex := deps.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Slot()
 	latestCommittee, exists := seatManager.CommitteeInSlot(latestSlotIndex)
 	if !exists {
 		return nil, ierrors.Errorf("committee for slot %d was not selected", latestSlotIndex)

--- a/components/inx/server_utxo.go
+++ b/components/inx/server_utxo.go
@@ -134,7 +134,7 @@ func NewLedgerUpdateBatchOperationConsumed(spent *utxoledger.Spent) (*inx.Ledger
 func (s *Server) ReadOutput(_ context.Context, id *inx.OutputId) (*inx.OutputResponse, error) {
 	engine := deps.Protocol.Engines.Main.Get()
 
-	latestCommitment := engine.Storage.Settings().LatestCommitment()
+	latestCommitment := engine.SyncManager.LatestCommitment()
 
 	outputID := id.Unwrap()
 
@@ -172,7 +172,7 @@ func (s *Server) ReadOutput(_ context.Context, id *inx.OutputId) (*inx.OutputRes
 
 func (s *Server) ReadUnspentOutputs(_ *inx.NoParams, srv inx.INX_ReadUnspentOutputsServer) error {
 	engine := deps.Protocol.Engines.Main.Get()
-	latestCommitment := engine.Storage.Settings().LatestCommitment()
+	latestCommitment := engine.SyncManager.LatestCommitment()
 
 	var innerErr error
 	err := engine.Ledger.ForEachUnspentOutput(func(output *utxoledger.Output) bool {

--- a/pkg/protocol/engine/blockdag/inmemoryblockdag/blockdag.go
+++ b/pkg/protocol/engine/blockdag/inmemoryblockdag/blockdag.go
@@ -59,7 +59,7 @@ func NewProvider(opts ...options.Option[BlockDAG]) module.Provider[*engine.Engin
 			}, event.WithWorkerPool(wp))
 
 			b.setRetainBlockFailureFunc(e.Retainer.RetainBlockFailure)
-			b.latestCommitmentFunc = e.Storage.Settings().LatestCommitment
+			b.latestCommitmentFunc = e.SyncManager.LatestCommitment
 
 			e.Events.BlockDAG.LinkTo(b.events)
 

--- a/pkg/protocol/engine/commitment_api.go
+++ b/pkg/protocol/engine/commitment_api.go
@@ -86,7 +86,7 @@ func (c *CommitmentAPI) Mutations() (acceptedBlocksBySlotCommitment map[iotago.C
 
 // Roots returns the roots of the slot.
 func (c *CommitmentAPI) Roots() (committedRoots *iotago.Roots, err error) {
-	if c.engine.Storage.Settings().LatestCommitment().Slot() < c.CommitmentID.Slot() {
+	if c.engine.SyncManager.LatestCommitment().Slot() < c.CommitmentID.Slot() {
 		return nil, ierrors.Errorf("slot %d is not committed yet", c.CommitmentID)
 	}
 
@@ -107,7 +107,7 @@ func (c *CommitmentAPI) Roots() (committedRoots *iotago.Roots, err error) {
 
 // BlocksIDsBySlotCommitmentID returns the accepted block IDs of the slot grouped by their SlotCommitmentID.
 func (c *CommitmentAPI) BlocksIDsBySlotCommitmentID() (map[iotago.CommitmentID]iotago.BlockIDs, error) {
-	if c.engine.Storage.Settings().LatestCommitment().Slot() < c.CommitmentID.Slot() {
+	if c.engine.SyncManager.LatestCommitment().Slot() < c.CommitmentID.Slot() {
 		return nil, ierrors.Errorf("slot %d is not committed yet", c.CommitmentID)
 	}
 
@@ -128,7 +128,7 @@ func (c *CommitmentAPI) BlocksIDsBySlotCommitmentID() (map[iotago.CommitmentID]i
 }
 
 func (c *CommitmentAPI) TransactionIDs() (iotago.TransactionIDs, error) {
-	if c.engine.Storage.Settings().LatestCommitment().Slot() < c.CommitmentID.Slot() {
+	if c.engine.SyncManager.LatestCommitment().Slot() < c.CommitmentID.Slot() {
 		return nil, ierrors.Errorf("slot %d is not committed yet", c.CommitmentID)
 	}
 

--- a/pkg/protocol/engine/congestioncontrol/scheduler/drr/scheduler.go
+++ b/pkg/protocol/engine/congestioncontrol/scheduler/drr/scheduler.go
@@ -59,7 +59,7 @@ func NewProvider(opts ...options.Option[Scheduler]) module.Provider[*engine.Engi
 
 		e.Constructed.OnTrigger(func() {
 			s.latestCommittedSlot = func() iotago.SlotIndex {
-				return e.Storage.Settings().LatestCommitment().Slot()
+				return e.SyncManager.LatestCommitment().Slot()
 			}
 			s.blockCache = e.BlockCache
 			e.Events.Scheduler.LinkTo(s.events)

--- a/pkg/protocol/engine/consensus/slotgadget/totalweightslotgadget/gadget.go
+++ b/pkg/protocol/engine/consensus/slotgadget/totalweightslotgadget/gadget.go
@@ -65,6 +65,7 @@ func NewProvider(opts ...options.Option[Gadget]) module.Provider[*engine.Engine,
 				func() {
 					g.mutex.Lock()
 					defer g.mutex.Unlock()
+
 					g.lastFinalizedSlot = e.Storage.Settings().LatestFinalizedSlot()
 				}()
 

--- a/pkg/protocol/engine/engine.go
+++ b/pkg/protocol/engine/engine.go
@@ -331,7 +331,7 @@ func (e *Engine) CommitmentAPI(commitmentID iotago.CommitmentID) (*CommitmentAPI
 		return nil, ierrors.New("engine is nil")
 	}
 
-	if e.Storage.Settings().LatestCommitment().Slot() < commitmentID.Slot() {
+	if e.SyncManager.LatestCommitment().Slot() < commitmentID.Slot() {
 		return nil, ierrors.Errorf("slot %d is not committed yet", commitmentID.Slot())
 	}
 

--- a/pkg/retainer/retainer/retainer.go
+++ b/pkg/retainer/retainer/retainer.go
@@ -56,6 +56,7 @@ func NewProvider() module.Provider[*engine.Engine, retainer.Retainer] {
 		r := New(e.Workers.CreateGroup("Retainer"),
 			e.Storage.Retainer,
 			func() iotago.SlotIndex {
+				// use settings in case SyncManager is not constructed yet.
 				if e.SyncManager == nil {
 					return e.Storage.Settings().LatestCommitment().Slot()
 				}
@@ -63,6 +64,7 @@ func NewProvider() module.Provider[*engine.Engine, retainer.Retainer] {
 				return e.SyncManager.LatestCommitment().Slot()
 			},
 			func() iotago.SlotIndex {
+				// use settings in case SyncManager is not constructed yet.
 				if e.SyncManager == nil {
 					return e.Storage.Settings().LatestFinalizedSlot()
 				}

--- a/pkg/retainer/retainer/retainer.go
+++ b/pkg/retainer/retainer/retainer.go
@@ -55,8 +55,20 @@ func NewProvider() module.Provider[*engine.Engine, retainer.Retainer] {
 	return module.Provide(func(e *engine.Engine) retainer.Retainer {
 		r := New(e.Workers.CreateGroup("Retainer"),
 			e.Storage.Retainer,
-			e.Storage.Settings().LatestCommitment().Slot,
-			e.Storage.Settings().LatestFinalizedSlot,
+			func() iotago.SlotIndex {
+				if e.SyncManager == nil {
+					return e.Storage.Settings().LatestCommitment().Slot()
+				}
+
+				return e.SyncManager.LatestCommitment().Slot()
+			},
+			func() iotago.SlotIndex {
+				if e.SyncManager == nil {
+					return e.Storage.Settings().LatestFinalizedSlot()
+				}
+
+				return e.SyncManager.LatestFinalizedSlot()
+			},
 			e.ErrorHandler("retainer"))
 
 		asyncOpt := event.WithWorkerPool(r.workerPool)

--- a/pkg/storage/permanent/settings.go
+++ b/pkg/storage/permanent/settings.go
@@ -251,6 +251,8 @@ func (s *Settings) SetSnapshotImported() (err error) {
 	return s.storeSnapshotImported.Set(true)
 }
 
+// LatestCommitment returns the last created commitment.
+// This method should not be called often as it reads data from the underlying KVStore. For frequent access, use SyncManager.
 func (s *Settings) LatestCommitment() *model.Commitment {
 	return s.latestCommitment()
 }
@@ -283,6 +285,8 @@ func (s *Settings) SetLatestFinalizedSlot(slot iotago.SlotIndex) (err error) {
 	return s.storeLatestFinalizedSlot.Set(slot)
 }
 
+// LatestFinalizedSlot returns the last finalized slot.
+// This method should not be called often as it reads data from the underlying KVStore. For frequent access, use SyncManager.
 func (s *Settings) LatestFinalizedSlot() iotago.SlotIndex {
 	latestFinalizedSlot, err := s.storeLatestFinalizedSlot.Get()
 	if err != nil {

--- a/pkg/tests/accounts_test.go
+++ b/pkg/tests/accounts_test.go
@@ -205,7 +205,7 @@ func Test_StakeDelegateAndDelayedClaim(t *testing.T) {
 	// CREATE NEW ACCOUNT WITH BLOCK ISSUER AND STAKING FEATURES FROM BASIC UTXO
 	newAccountBlockIssuerKey := tpkg.RandBlockIssuerKey()
 	// set the expiry slot of the transitioned genesis account to the latest committed + MaxCommittableAge
-	newAccountExpirySlot := node1.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Slot() + ts.API.ProtocolParameters().MaxCommittableAge()
+	newAccountExpirySlot := node1.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Slot() + ts.API.ProtocolParameters().MaxCommittableAge()
 
 	stakedAmount := iotago.BaseToken(10000)
 
@@ -421,7 +421,7 @@ func Test_ImplicitAccounts(t *testing.T) {
 		),
 		mock.WithAccountAmount(mock.MinIssuerAccountAmount(ts.API.ProtocolParameters())),
 	)
-	block2Commitment := node1.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment()
+	block2Commitment := node1.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment()
 	block2 := ts.IssueBasicBlockWithOptions("block2", newUserWallet, tx2, mock.WithStrongParents(latestParents...))
 	latestParents = ts.CommitUntilSlot(block2Slot, block2.ID())
 
@@ -543,7 +543,7 @@ func Test_NegativeBIC_BlockIssuerLocked(t *testing.T) {
 	// Try to issue more blocks from each of the issuers - one succeeds in issuing a block,
 	// the other has the block rejected in the PostSolidFilter as his account has negative BIC value.
 	{
-		block2Commitment := node1.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment()
+		block2Commitment := node1.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment()
 
 		block21 := ts.IssueBasicBlockWithOptions("block2.1", wallet1, &iotago.TaggedData{}, mock.WithSlotCommitment(block2Commitment))
 
@@ -586,7 +586,7 @@ func Test_NegativeBIC_BlockIssuerLocked(t *testing.T) {
 				Mana:      iotago.Mana(allottedBIC),
 			}}, "Genesis:0")
 
-		block3Commitment := node1.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment()
+		block3Commitment := node1.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment()
 		// Wallet 1 whose account is not locked is issuing the block to unlock the account of wallet 2.
 		block31 := ts.IssueBasicBlockWithOptions("block3.1", wallet1, tx1, mock.WithStrongParents(latestParents...), mock.WithSlotCommitment(block3Commitment))
 
@@ -618,7 +618,7 @@ func Test_NegativeBIC_BlockIssuerLocked(t *testing.T) {
 
 	// Issue block from the unlocked account of wallet 2 to make sure that it's actually unlocked.
 	{
-		block4Commitment := node1.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment()
+		block4Commitment := node1.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment()
 
 		block4 := ts.IssueBasicBlockWithOptions("block4", wallet2, &iotago.TaggedData{}, mock.WithStrongParents(latestParents...), mock.WithSlotCommitment(block4Commitment))
 
@@ -768,7 +768,7 @@ func Test_NegativeBIC_AccountOutput(t *testing.T) {
 				Mana:      iotago.Mana(allottedBIC),
 			}}, "Genesis:0")
 
-		block2Commitment := node1.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment()
+		block2Commitment := node1.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment()
 		// Wallet 2 whose account is not locked is issuing the block to unlock the account of wallet 1.
 		block2 := ts.IssueBasicBlockWithOptions("block2", wallet2, tx2, mock.WithStrongParents(latestParents...), mock.WithSlotCommitment(block2Commitment))
 
@@ -805,7 +805,7 @@ func Test_NegativeBIC_AccountOutput(t *testing.T) {
 			mock.WithBlockIssuerExpirySlot(newExpirySlot),
 		)
 
-		block3Commitment := node1.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment()
+		block3Commitment := node1.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment()
 
 		// Wallet 1, which already has non-negative BIC issues the block.
 		block3 := ts.IssueBasicBlockWithOptions("block3", wallet1, tx3, mock.WithStrongParents(latestParents...), mock.WithSlotCommitment(block3Commitment))
@@ -843,7 +843,7 @@ func Test_NegativeBIC_AccountOutput(t *testing.T) {
 		// create a transaction which destroys the genesis account.
 
 		tx4 := wallet1.DestroyAccount("TX4", "TX3:0")
-		block4Commitment := node1.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment()
+		block4Commitment := node1.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment()
 
 		block4 := ts.IssueBasicBlockWithOptions("block4", wallet2, tx4, mock.WithStrongParents(latestParents...), mock.WithSlotCommitment(block4Commitment))
 		latestParents = ts.CommitUntilSlot(block4Slot, block4.ID())
@@ -979,7 +979,7 @@ func Test_NegativeBIC_AccountOwnedBasicOutputLocked(t *testing.T) {
 
 	// TRY TO SPEND THE BASIC OUTPUT FROM AN ACCOUNT ADDRESS
 	{
-		block2Commitment := node1.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment()
+		block2Commitment := node1.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment()
 
 		tx2 := wallet1.SendFundsFromAccount(
 			"TX2",
@@ -1026,7 +1026,7 @@ func Test_NegativeBIC_AccountOwnedBasicOutputLocked(t *testing.T) {
 				Mana:      iotago.Mana(allottedBIC),
 			}}, "TX0:1")
 
-		block3Commitment := node1.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment()
+		block3Commitment := node1.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment()
 
 		// Wallet 2 whose account is not locked is issuing the block to unlock the account of wallet 1.
 		block3 := ts.IssueBasicBlockWithOptions("block3", wallet2, tx3, mock.WithStrongParents(latestParents...), mock.WithSlotCommitment(block3Commitment))
@@ -1060,7 +1060,7 @@ func Test_NegativeBIC_AccountOwnedBasicOutputLocked(t *testing.T) {
 	block4Slot := ts.CurrentSlot()
 	// SPEND THE BASIC OUTPUT FROM AN ACCOUNT ADDRESS
 	{
-		block4Commitment := node1.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment()
+		block4Commitment := node1.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment()
 
 		tx4 := wallet1.SendFundsFromAccount(
 			"TX4",

--- a/pkg/tests/protocol_engine_rollback_test.go
+++ b/pkg/tests/protocol_engine_rollback_test.go
@@ -176,8 +176,8 @@ func TestProtocol_EngineRollbackFinalization(t *testing.T) {
 
 	// Assert state of the forked engine after rollback.
 	{
-		require.EqualValues(t, 13, newEngine.Storage.Settings().LatestCommitment().Slot())
-		require.EqualValues(t, 13, newEngine.Storage.Settings().LatestFinalizedSlot())
+		require.EqualValues(t, 13, newEngine.SyncManager.LatestCommitment().Slot())
+		require.EqualValues(t, 13, newEngine.SyncManager.LatestFinalizedSlot())
 		require.EqualValues(t, 13, newEngine.EvictionState.LastEvictedSlot())
 
 		for epoch := 0; epoch <= 2; epoch++ {
@@ -370,8 +370,8 @@ func TestProtocol_EngineRollbackNoFinalization(t *testing.T) {
 
 	// Assert state of the forked engine after rollback.
 	{
-		require.EqualValues(t, 13, newEngine.Storage.Settings().LatestCommitment().Slot())
-		require.EqualValues(t, 8, newEngine.Storage.Settings().LatestFinalizedSlot())
+		require.EqualValues(t, 13, newEngine.SyncManager.LatestCommitment().Slot())
+		require.EqualValues(t, 8, newEngine.SyncManager.LatestFinalizedSlot())
 		require.EqualValues(t, 13, newEngine.EvictionState.LastEvictedSlot())
 
 		for epoch := 0; epoch <= 2; epoch++ {
@@ -564,8 +564,8 @@ func TestProtocol_EngineRollbackNoFinalizationLastSlot(t *testing.T) {
 
 	// Assert state of the forked engine after rollback.
 	{
-		require.EqualValues(t, 15, newEngine.Storage.Settings().LatestCommitment().Slot())
-		require.EqualValues(t, 8, newEngine.Storage.Settings().LatestFinalizedSlot())
+		require.EqualValues(t, 15, newEngine.SyncManager.LatestCommitment().Slot())
+		require.EqualValues(t, 8, newEngine.SyncManager.LatestFinalizedSlot())
 		require.EqualValues(t, 15, newEngine.EvictionState.LastEvictedSlot())
 
 		for epoch := 0; epoch <= 2; epoch++ {
@@ -758,8 +758,8 @@ func TestProtocol_EngineRollbackNoFinalizationBeforePointOfNoReturn(t *testing.T
 
 	// Assert state of the forked engine after rollback.
 	{
-		require.EqualValues(t, 9, newEngine.Storage.Settings().LatestCommitment().Slot())
-		require.EqualValues(t, 8, newEngine.Storage.Settings().LatestFinalizedSlot())
+		require.EqualValues(t, 9, newEngine.SyncManager.LatestCommitment().Slot())
+		require.EqualValues(t, 8, newEngine.SyncManager.LatestFinalizedSlot())
 		require.EqualValues(t, 9, newEngine.EvictionState.LastEvictedSlot())
 
 		for epoch := 0; epoch <= 1; epoch++ {

--- a/pkg/tests/protocol_engine_switching_test.go
+++ b/pkg/tests/protocol_engine_switching_test.go
@@ -98,7 +98,7 @@ func TestProtocol_EngineSwitching(t *testing.T) {
 			protocol.WithSyncManagerProvider(
 				trivialsyncmanager.NewProvider(
 					trivialsyncmanager.WithBootstrappedFunc(func(e *engine.Engine) bool {
-						return e.Storage.Settings().LatestCommitment().Slot() >= expectedCommittedSlotAfterPartitionMerge && e.Notarization.IsBootstrapped()
+						return e.SyncManager.LatestCommitment().Slot() >= expectedCommittedSlotAfterPartitionMerge && e.Notarization.IsBootstrapped()
 					}),
 				),
 			),
@@ -420,7 +420,7 @@ func TestProtocol_EngineSwitching_CommitteeRotation(t *testing.T) {
 		protocol.WithSyncManagerProvider(
 			trivialsyncmanager.NewProvider(
 				trivialsyncmanager.WithBootstrappedFunc(func(e *engine.Engine) bool {
-					return e.Storage.Settings().LatestCommitment().Slot() >= expectedCommittedSlotAfterPartitionMerge && e.Notarization.IsBootstrapped()
+					return e.SyncManager.LatestCommitment().Slot() >= expectedCommittedSlotAfterPartitionMerge && e.Notarization.IsBootstrapped()
 				}),
 			),
 		),

--- a/pkg/tests/reward_test.go
+++ b/pkg/tests/reward_test.go
@@ -107,7 +107,7 @@ func Test_Delegation_DelayedClaimingDestroyOutputWithoutRewards(t *testing.T) {
 	block1 := ts.IssueBasicBlockWithOptions("block1", ts.DefaultWallet(), tx1)
 
 	// TRANSITION TO DELAYED CLAIMING (IN THE SAME SLOT)
-	latestCommitment := ts.DefaultWallet().Node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment()
+	latestCommitment := ts.DefaultWallet().Node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment()
 	apiForSlot := ts.DefaultWallet().Node.Protocol.APIForSlot(block1_2Slot)
 
 	futureBoundedSlotIndex := latestCommitment.Slot() + apiForSlot.ProtocolParameters().MinCommittableAge()
@@ -237,7 +237,7 @@ func Test_RewardInputCannotPointToNFTOutput(t *testing.T) {
 			0,
 		),
 		mock.WithCommitmentInput(&iotago.CommitmentInput{
-			CommitmentID: ts.DefaultWallet().Node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment().MustID(),
+			CommitmentID: ts.DefaultWallet().Node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment().MustID(),
 		}))
 
 	ts.IssueBasicBlockWithOptions("block2", ts.DefaultWallet(), tx2, mock.WithStrongParents(latestParents...))

--- a/pkg/tests/validator_test.go
+++ b/pkg/tests/validator_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/iotaledger/hive.go/core/safemath"
 	"github.com/iotaledger/hive.go/lo"
 	"github.com/iotaledger/hive.go/log"
 	"github.com/iotaledger/hive.go/runtime/options"
 	"github.com/iotaledger/iota-core/pkg/testsuite"
 	"github.com/iotaledger/iota-core/pkg/testsuite/mock"
-	"github.com/stretchr/testify/require"
 
 	iotago "github.com/iotaledger/iota.go/v4"
 )
@@ -267,7 +268,7 @@ func validatorTest(t *testing.T, test ValidatorTest) {
 		for subslotIdx := uint8(0); subslotIdx < test.issuancePerSlot; subslotIdx++ {
 			for _, node := range ts.Validators() {
 				blockName := fmt.Sprintf("block-%s-%d/%d", node.Name, ts.CurrentSlot(), subslotIdx)
-				latestCommitment := node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment()
+				latestCommitment := node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment()
 
 				issuingTime := slotStartTime.
 					Add(issuancePeriod * time.Duration(subslotIdx)).
@@ -291,7 +292,7 @@ func validatorTest(t *testing.T, test ValidatorTest) {
 	var totalStake iotago.BaseToken = 0
 	var totalValidatorStake iotago.BaseToken = 0
 	lo.ForEach(ts.Validators(), func(n *mock.Node) {
-		latestCommittedSlot := ts.DefaultWallet().Node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Slot()
+		latestCommittedSlot := ts.DefaultWallet().Node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Slot()
 		accountData, exists, err := ts.DefaultWallet().Node.Protocol.Engines.Main.Get().Ledger.Account(n.Validator.AccountID, latestCommittedSlot)
 		if err != nil || !exists {
 			t.Fatal(exists, err)
@@ -357,7 +358,7 @@ type epochReward struct {
 // as in the epoch for which to calculate rewards.
 func calculateEpochReward(t *testing.T, ts *testsuite.TestSuite, accountID iotago.AccountID, epoch iotago.EpochIndex, epochPerformanceFactor uint64, totalStake iotago.BaseToken, totalValidatorStake iotago.BaseToken) epochReward {
 
-	latestCommittedSlot := ts.DefaultWallet().Node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Slot()
+	latestCommittedSlot := ts.DefaultWallet().Node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Slot()
 	targetReward := lo.PanicOnErr(ts.API.ProtocolParameters().RewardsParameters().TargetReward(epoch, ts.API))
 	accountData, exists, err := ts.DefaultWallet().Node.Protocol.Engines.Main.Get().Ledger.Account(accountID, latestCommittedSlot)
 	if err != nil || !exists {
@@ -384,7 +385,7 @@ func calculateEpochReward(t *testing.T, ts *testsuite.TestSuite, accountID iotag
 // For testing purposes, assumes that the account's staking data is the same in the latest committed slot
 // as in the epoch for which to calculate rewards.
 func calculateValidatorReward(t *testing.T, ts *testsuite.TestSuite, accountID iotago.AccountID, epochRewards []epochReward, startEpoch iotago.EpochIndex, claimingEpoch iotago.EpochIndex) iotago.Mana {
-	latestCommittedSlot := ts.DefaultWallet().Node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Slot()
+	latestCommittedSlot := ts.DefaultWallet().Node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Slot()
 	accountData, exists, err := ts.DefaultWallet().Node.Protocol.Engines.Main.Get().Ledger.Account(accountID, latestCommittedSlot)
 	if err != nil || !exists {
 		t.Fatal(exists, err)

--- a/pkg/testsuite/chainmanager.go
+++ b/pkg/testsuite/chainmanager.go
@@ -16,7 +16,7 @@ func (t *TestSuite) AssertChainManagerIsSolid(nodes ...*mock.Node) {
 			}
 
 			latestChainCommitment := chain.LatestCommitment.Get()
-			latestCommitment := node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment()
+			latestCommitment := node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment()
 
 			if latestCommitment.ID() != latestChainCommitment.ID() {
 				return ierrors.Errorf("AssertChainManagerIsSolid: %s: latest commitment is not equal, expected %s, got %s", node.Name, latestCommitment.ID(), latestChainCommitment.ID())

--- a/pkg/testsuite/mock/blockissuer.go
+++ b/pkg/testsuite/mock/blockissuer.go
@@ -387,8 +387,8 @@ func (i *BlockIssuer) AttachBlock(ctx context.Context, iotaBlock *iotago.Block, 
 	}
 
 	if iotaBlock.Header.SlotCommitmentID == iotago.EmptyCommitmentID {
-		iotaBlock.Header.SlotCommitmentID = node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment().MustID()
-		iotaBlock.Header.LatestFinalizedSlot = node.Protocol.Engines.Main.Get().Storage.Settings().LatestFinalizedSlot()
+		iotaBlock.Header.SlotCommitmentID = node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment().MustID()
+		iotaBlock.Header.LatestFinalizedSlot = node.Protocol.Engines.Main.Get().SyncManager.LatestFinalizedSlot()
 		resign = true
 	}
 
@@ -511,7 +511,7 @@ func (i *BlockIssuer) setDefaultBlockParams(blockParams *BlockHeaderParams, node
 	}
 
 	if blockParams.LatestFinalizedSlot == nil {
-		latestFinalizedSlot := node.Protocol.Engines.Main.Get().Storage.Settings().LatestFinalizedSlot()
+		latestFinalizedSlot := node.Protocol.Engines.Main.Get().SyncManager.LatestFinalizedSlot()
 		blockParams.LatestFinalizedSlot = &latestFinalizedSlot
 	}
 
@@ -534,7 +534,7 @@ func (i *BlockIssuer) getAddressableCommitment(currentAPI iotago.API, blockIssui
 	protoParams := currentAPI.ProtocolParameters()
 	blockSlot := currentAPI.TimeProvider().SlotFromTime(blockIssuingTime)
 
-	commitment := node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment()
+	commitment := node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment()
 
 	if blockSlot > commitment.Slot+protoParams.MaxCommittableAge() {
 		return nil, ierrors.Wrapf(ErrBlockTooRecent, "can't issue block: block slot %d is too far in the future, latest commitment is %d", blockSlot, commitment.Slot)

--- a/pkg/testsuite/mock/blockissuer_acceptance_loss.go
+++ b/pkg/testsuite/mock/blockissuer_acceptance_loss.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (i *BlockIssuer) reviveChain(issuingTime time.Time, node *Node) (*iotago.Commitment, iotago.BlockID, error) {
-	lastCommittedSlot := node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Slot()
+	lastCommittedSlot := node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Slot()
 	apiForSlot := node.Protocol.APIForSlot(lastCommittedSlot)
 
 	// Get a rootblock as recent as possible for the parent.

--- a/pkg/testsuite/mock/wallet_transactions.go
+++ b/pkg/testsuite/mock/wallet_transactions.go
@@ -44,7 +44,7 @@ func (w *Wallet) CreateAccountFromInput(transactionName string, inputName string
 	signedTransaction := w.createSignedTransactionWithOptions(
 		transactionName,
 		WithCommitmentInput(&iotago.CommitmentInput{
-			CommitmentID: w.Node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment().MustID(),
+			CommitmentID: w.Node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment().MustID(),
 		}),
 		WithInputs(utxoledger.Outputs{input}),
 		WithOutputs(outputStates),
@@ -90,7 +90,7 @@ func (w *Wallet) CreateDelegationFromInput(transactionName string, inputName str
 	signedTransaction := w.createSignedTransactionWithOptions(
 		transactionName,
 		WithCommitmentInput(&iotago.CommitmentInput{
-			CommitmentID: w.Node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment().MustID(),
+			CommitmentID: w.Node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment().MustID(),
 		}),
 		WithInputs(utxoledger.Outputs{input}),
 		WithOutputs(outputStates),
@@ -101,7 +101,7 @@ func (w *Wallet) CreateDelegationFromInput(transactionName string, inputName str
 }
 
 func (w *Wallet) DelegationStartFromSlot(slot iotago.SlotIndex) iotago.EpochIndex {
-	latestCommitment := w.Node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment()
+	latestCommitment := w.Node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment()
 	apiForSlot := w.Node.Protocol.APIForSlot(slot)
 
 	pastBoundedSlotIndex := latestCommitment.Slot() + apiForSlot.ProtocolParameters().MaxCommittableAge()
@@ -117,7 +117,7 @@ func (w *Wallet) DelegationStartFromSlot(slot iotago.SlotIndex) iotago.EpochInde
 }
 
 func (w *Wallet) DelegationEndFromSlot(slot iotago.SlotIndex) iotago.EpochIndex {
-	latestCommitment := w.Node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment()
+	latestCommitment := w.Node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment()
 	apiForSlot := w.Node.Protocol.APIForSlot(slot)
 
 	futureBoundedSlotIndex := latestCommitment.Slot() + apiForSlot.ProtocolParameters().MinCommittableAge()
@@ -162,7 +162,7 @@ func (w *Wallet) DelayedClaimingTransition(transactionName string, inputName str
 	signedTransaction := w.createSignedTransactionWithOptions(
 		transactionName,
 		WithCommitmentInput(&iotago.CommitmentInput{
-			CommitmentID: w.Node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment().MustID(),
+			CommitmentID: w.Node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment().MustID(),
 		}),
 		WithInputs(utxoledger.Outputs{input}),
 		WithOutputs(iotago.Outputs[iotago.Output]{delegationOutput}),
@@ -192,7 +192,7 @@ func (w *Wallet) TransitionAccount(transactionName string, inputName string, opt
 			AccountID: accountOutput.AccountID,
 		}),
 		WithCommitmentInput(&iotago.CommitmentInput{
-			CommitmentID: w.Node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment().MustID(),
+			CommitmentID: w.Node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment().MustID(),
 		}),
 		WithOutputs(iotago.Outputs[iotago.Output]{accountOutput}),
 	)
@@ -222,7 +222,7 @@ func (w *Wallet) DestroyAccount(transactionName string, inputName string) *iotag
 			AccountID: inputAccount.AccountID,
 		}),
 		WithCommitmentInput(&iotago.CommitmentInput{
-			CommitmentID: w.Node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment().MustID(),
+			CommitmentID: w.Node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment().MustID(),
 		}),
 		WithAccountInput(input),
 		WithOutputs(destructionOutputs),
@@ -291,7 +291,7 @@ func (w *Wallet) TransitionImplicitAccountToAccountOutput(transactionName string
 			AccountID: implicitAccountID,
 		}),
 		WithCommitmentInput(&iotago.CommitmentInput{
-			CommitmentID: w.Node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment().MustID(),
+			CommitmentID: w.Node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment().MustID(),
 		}),
 		WithInputs(utxoledger.Outputs{input}),
 		WithOutputs(iotago.Outputs[iotago.Output]{accountOutput}),
@@ -362,7 +362,7 @@ func (w *Wallet) RemoveFeatureFromAccount(featureType iotago.FeatureType, transa
 			AccountID: accountOutput.AccountID,
 		}),
 		WithCommitmentInput(&iotago.CommitmentInput{
-			CommitmentID: w.Node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment().MustID(),
+			CommitmentID: w.Node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment().MustID(),
 		}),
 		WithOutputs(iotago.Outputs[iotago.Output]{accountOutput}),
 	)
@@ -486,7 +486,7 @@ func (w *Wallet) ClaimValidatorRewards(transactionName string, inputName string)
 			AccountID: accountOutput.AccountID,
 		}),
 		WithCommitmentInput(&iotago.CommitmentInput{
-			CommitmentID: w.Node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment().MustID(),
+			CommitmentID: w.Node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment().MustID(),
 		}),
 		WithOutputs(iotago.Outputs[iotago.Output]{accountOutput}),
 	)
@@ -586,7 +586,7 @@ func (w *Wallet) ClaimDelegatorRewards(transactionName string, inputName string)
 			rewardMana,
 		),
 		WithCommitmentInput(&iotago.CommitmentInput{
-			CommitmentID: w.Node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment().MustID(),
+			CommitmentID: w.Node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment().MustID(),
 		}),
 		WithOutputs(outputStates),
 	)

--- a/pkg/testsuite/storage_settings.go
+++ b/pkg/testsuite/storage_settings.go
@@ -81,9 +81,13 @@ func (t *TestSuite) AssertLatestCommitmentSlotIndex(slot iotago.SlotIndex, nodes
 
 	for _, node := range nodes {
 		t.Eventually(func() error {
-			latestCommittedSlot := node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Slot()
-			if slot != latestCommittedSlot {
-				return ierrors.Errorf("AssertLatestCommitmentSlotIndex: %s: expected %v, got %v", node.Name, slot, latestCommittedSlot)
+			latestCommittedSlotSettings := node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Slot()
+			if slot != latestCommittedSlotSettings {
+				return ierrors.Errorf("AssertLatestCommitmentSlotIndex: %s: expected %v, got %v in settings", node.Name, slot, latestCommittedSlotSettings)
+			}
+			latestCommittedSlotSyncManager := node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Slot()
+			if slot != latestCommittedSlotSyncManager {
+				return ierrors.Errorf("AssertLatestCommitmentSlotIndex: %s: expected %v, got %v in sync manager", node.Name, slot, latestCommittedSlotSyncManager)
 			}
 
 			return nil
@@ -112,6 +116,10 @@ func (t *TestSuite) AssertLatestFinalizedSlot(slot iotago.SlotIndex, nodes ...*m
 		t.Eventually(func() error {
 			if slot != node.Protocol.Engines.Main.Get().Storage.Settings().LatestFinalizedSlot() {
 				return ierrors.Errorf("AssertLatestFinalizedSlot: %s: expected %d, got %d from settings", node.Name, slot, node.Protocol.Engines.Main.Get().Storage.Settings().LatestFinalizedSlot())
+			}
+
+			if slot != node.Protocol.Engines.Main.Get().SyncManager.LatestFinalizedSlot() {
+				return ierrors.Errorf("AssertLatestFinalizedSlot: %s: expected %d, got %d from from SyncManager", node.Name, slot, node.Protocol.Engines.Main.Get().SyncManager.LatestFinalizedSlot())
 			}
 
 			return nil

--- a/pkg/testsuite/testsuite_issue_blocks.go
+++ b/pkg/testsuite/testsuite_issue_blocks.go
@@ -262,7 +262,7 @@ func (t *TestSuite) CommitUntilSlot(slot iotago.SlotIndex, parents ...iotago.Blo
 	// then issue one more block to accept the last in the chain which will trigger commitment of the second last in the chain
 	activeValidators := t.Validators()
 
-	latestCommittedSlot := activeValidators[0].Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Slot()
+	latestCommittedSlot := activeValidators[0].Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Slot()
 	if latestCommittedSlot >= slot {
 		return parents
 	}
@@ -283,7 +283,7 @@ func (t *TestSuite) CommitUntilSlot(slot iotago.SlotIndex, parents ...iotago.Blo
 
 			if committeeAtBlockSlot.HasAccount(node.Validator.AccountID) {
 				blockName := fmt.Sprintf("chain-%s-%d-%s", parents[0].Alias(), chainIndex, node.Name)
-				latestCommitment := node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment()
+				latestCommitment := node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment()
 				tips = []iotago.BlockID{t.IssueValidationBlockWithHeaderOptions(blockName, node, mock.WithSlotCommitment(latestCommitment), mock.WithStrongParents(tips...)).ID()}
 			}
 		}
@@ -293,7 +293,7 @@ func (t *TestSuite) CommitUntilSlot(slot iotago.SlotIndex, parents ...iotago.Blo
 			require.True(t.Testing, exists, "node: %s: does not have committee selected for slot %d", node.Name, t.currentSlot)
 			if committeeAtBlockSlot.HasAccount(node.Validator.AccountID) {
 				blockName := fmt.Sprintf("chain-%s-%d-%s", parents[0].Alias(), chainIndex+1, node.Name)
-				latestCommitment := node.Protocol.Engines.Main.Get().Storage.Settings().LatestCommitment().Commitment()
+				latestCommitment := node.Protocol.Engines.Main.Get().SyncManager.LatestCommitment().Commitment()
 				tips = []iotago.BlockID{t.IssueValidationBlockWithHeaderOptions(blockName, node, mock.WithSlotCommitment(latestCommitment), mock.WithStrongParents(tips...)).ID()}
 			}
 		}


### PR DESCRIPTION
I changes Settings.LatestCommitment and Settings.LastFinalizedSlot usages that require taking the values from the underlying KVStore, to use SyncManager which stores the value in memory. 
Values from Settings are still used during component initialization to avoid potential problems due to order in which components are initialized and in some low-level Storage logic.