### PR TITLE
Fix race condition when stopping publishing candidate payloads.

### DIFF
--- a/components/restapi/core/accounts.go
+++ b/components/restapi/core/accounts.go
@@ -269,11 +269,9 @@ func selectedCommittee(c echo.Context) (*api.CommitteeResponse, error) {
 		// by default we return current epoch
 		slot = timeProvider.SlotFromTime(time.Now())
 		epoch = timeProvider.EpochFromSlot(slot)
-	} else {
-		slot = timeProvider.EpochEnd(epoch)
 	}
 
-	seatedAccounts, exists := deps.Protocol.Engines.Main.Get().SybilProtection.SeatManager().CommitteeInSlot(slot)
+	seatedAccounts, exists := deps.Protocol.Engines.Main.Get().SybilProtection.SeatManager().CommitteeInEpoch(epoch)
 	if !exists {
 		return &api.CommitteeResponse{
 			Epoch: epoch,

--- a/tools/docker-network/docker-compose.yml
+++ b/tools/docker-network/docker-compose.yml
@@ -299,6 +299,7 @@ services:
       --inx.address=node-1-validator:9029
       --validator.ignoreBootstrapped=true
       --validator.accountAddress=rms1pzg8cqhfxqhq7pt37y8cs4v5u4kcc48lquy2k73ehsdhf5ukhya3y5rx2w6
+      --validator.issueCandidacyPayload=${ISSUE_CANDIDACY_PAYLOAD_V1:-true}
 
   inx-validator-2:
     image: iotaledger/inx-validator:1.0-alpha
@@ -315,6 +316,7 @@ services:
       --logger.level=debug
       --inx.address=node-2-validator:9029
       --validator.accountAddress=rms1pqm4xk8e9ny5w5rxjkvtp249tfhlwvcshyr3pc0665jvp7g3hc875k538hl
+      --validator.issueCandidacyPayload=${ISSUE_CANDIDACY_PAYLOAD_V2:-true}
 
   inx-validator-3:
     image: iotaledger/inx-validator:1.0-alpha
@@ -331,6 +333,7 @@ services:
       --logger.level=debug
       --inx.address=node-3-validator:9029
       --validator.accountAddress=rms1pp4wuuz0y42caz48vv876qfpmffswsvg40zz8v79sy8cp0jfxm4kunflcgt
+      --validator.issueCandidacyPayload=${ISSUE_CANDIDACY_PAYLOAD_V3:-true}
 
   inx-validator-4:
     image: iotaledger/inx-validator:1.0-alpha
@@ -347,7 +350,7 @@ services:
       --logger.level=debug
       --inx.address=node-4-validator:9029
       --validator.accountAddress=rms1pr8cxs3dzu9xh4cduff4dd4cxdthpjkpwmz2244f75m0urslrsvtsshrrjw
-      --logger.level=debug
+      --validator.issueCandidacyPayload=${ISSUE_CANDIDACY_PAYLOAD_V4:-true}
 
 # Create our own network
 networks:

--- a/tools/docker-network/tests/committeerotation_test.go
+++ b/tools/docker-network/tests/committeerotation_test.go
@@ -152,7 +152,7 @@ func Test_NoCandidacyPayload(t *testing.T) {
 	d.AddValidatorNode("V4", "docker-network-inx-validator-4-1", "http://localhost:8040", "rms1pr8cxs3dzu9xh4cduff4dd4cxdthpjkpwmz2244f75m0urslrsvtsshrrjw")
 	d.AddNode("node5", "docker-network-node-5-1", "http://localhost:8090")
 
-	err := d.Run()
+	err := d.Run(map[string]bool{"V1": false, "V2": false, "V3": false, "V4": false})
 	require.NoError(t, err)
 
 	err = d.WaitUntilSync()
@@ -164,7 +164,7 @@ func Test_NoCandidacyPayload(t *testing.T) {
 	fmt.Println("First finalized slot: ", prevFinalizedSlot)
 	currentEpoch := clt.CommittedAPI().TimeProvider().EpochFromSlot(status.LatestAcceptedBlockSlot)
 
-	d.StopIssueCandidacyPayload(d.Nodes()...)
+	d.AssertCommittee(currentEpoch+1, d.AccountsFromNodes(d.Nodes()...))
 
 	// Due to no candidacy payloads, committee should be reused, remain 4 validators
 	d.AssertCommittee(currentEpoch+2, d.AccountsFromNodes(d.Nodes()...))
@@ -179,7 +179,7 @@ func Test_NoCandidacyPayload(t *testing.T) {
 	})
 
 	// Start issuing candidacy payloads for 3 validators, and check if committee size is 3
-	d.StartIssueCandidacyPayload(d.Nodes("V1", "V2", "V3")...)
+	d.SetIssueCandidacyPayload(map[string]bool{"V1": true, "V2": true, "V3": true, "V4": false})
 	d.AssertCommittee(currentEpoch+4, d.AccountsFromNodes(d.Nodes("V1", "V2", "V3")...))
 }
 

--- a/tools/docker-network/tests/committeerotation_test.go
+++ b/tools/docker-network/tests/committeerotation_test.go
@@ -146,13 +146,13 @@ func Test_NoCandidacyPayload(t *testing.T) {
 		))
 	defer d.Stop()
 
-	d.AddValidatorNode("V1", "docker-network-inx-validator-1-1", "http://localhost:8050", "rms1pzg8cqhfxqhq7pt37y8cs4v5u4kcc48lquy2k73ehsdhf5ukhya3y5rx2w6")
-	d.AddValidatorNode("V2", "docker-network-inx-validator-2-1", "http://localhost:8060", "rms1pqm4xk8e9ny5w5rxjkvtp249tfhlwvcshyr3pc0665jvp7g3hc875k538hl")
-	d.AddValidatorNode("V3", "docker-network-inx-validator-3-1", "http://localhost:8070", "rms1pp4wuuz0y42caz48vv876qfpmffswsvg40zz8v79sy8cp0jfxm4kunflcgt")
-	d.AddValidatorNode("V4", "docker-network-inx-validator-4-1", "http://localhost:8040", "rms1pr8cxs3dzu9xh4cduff4dd4cxdthpjkpwmz2244f75m0urslrsvtsshrrjw")
+	d.AddValidatorNode("V1", "docker-network-inx-validator-1-1", "http://localhost:8050", "rms1pzg8cqhfxqhq7pt37y8cs4v5u4kcc48lquy2k73ehsdhf5ukhya3y5rx2w6", false)
+	d.AddValidatorNode("V2", "docker-network-inx-validator-2-1", "http://localhost:8060", "rms1pqm4xk8e9ny5w5rxjkvtp249tfhlwvcshyr3pc0665jvp7g3hc875k538hl", false)
+	d.AddValidatorNode("V3", "docker-network-inx-validator-3-1", "http://localhost:8070", "rms1pp4wuuz0y42caz48vv876qfpmffswsvg40zz8v79sy8cp0jfxm4kunflcgt", false)
+	d.AddValidatorNode("V4", "docker-network-inx-validator-4-1", "http://localhost:8040", "rms1pr8cxs3dzu9xh4cduff4dd4cxdthpjkpwmz2244f75m0urslrsvtsshrrjw", false)
 	d.AddNode("node5", "docker-network-node-5-1", "http://localhost:8090")
 
-	err := d.Run(map[string]bool{"V1": false, "V2": false, "V3": false, "V4": false})
+	err := d.Run()
 	require.NoError(t, err)
 
 	err = d.WaitUntilSync()
@@ -179,7 +179,7 @@ func Test_NoCandidacyPayload(t *testing.T) {
 	})
 
 	// Start issuing candidacy payloads for 3 validators, and check if committee size is 3
-	d.SetIssueCandidacyPayload(map[string]bool{"V1": true, "V2": true, "V3": true, "V4": false})
+	d.StartIssueCandidacyPayload("V1", "V2", "V3")
 	d.AssertCommittee(currentEpoch+4, d.AccountsFromNodes(d.Nodes("V1", "V2", "V3")...))
 }
 

--- a/tools/docker-network/tests/committeerotation_test.go
+++ b/tools/docker-network/tests/committeerotation_test.go
@@ -179,7 +179,7 @@ func Test_NoCandidacyPayload(t *testing.T) {
 	})
 
 	// Start issuing candidacy payloads for 3 validators, and check if committee size is 3
-	d.StartIssueCandidacyPayload("V1", "V2", "V3")
+	d.StartIssueCandidacyPayload(d.Nodes("V1", "V2", "V3")...)
 	d.AssertCommittee(currentEpoch+4, d.AccountsFromNodes(d.Nodes("V1", "V2", "V3")...))
 }
 

--- a/tools/docker-network/tests/dockerframework.go
+++ b/tools/docker-network/tests/dockerframework.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"slices"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -297,29 +296,25 @@ func (d *DockerTestFramework) AccountsFromNodes(nodes ...*Node) []string {
 	return accounts
 }
 
-func (d *DockerTestFramework) StartIssueCandidacyPayload(nodeNames ...string) {
-	if len(nodeNames) == 0 {
+func (d *DockerTestFramework) StartIssueCandidacyPayload(nodes ...*Node) {
+	if len(nodes) == 0 {
 		return
 	}
 
-	for _, node := range d.nodes {
-		if slices.Contains(nodeNames, node.Name) {
-			node.IssueCandidacyPayload = true
-		}
+	for _, node := range nodes {
+		node.IssueCandidacyPayload = true
 	}
 
 	d.DockerComposeUp(true)
 }
 
-func (d *DockerTestFramework) StopIssueCandidacyPayload(nodeNames ...string) {
-	if len(nodeNames) == 0 {
+func (d *DockerTestFramework) StopIssueCandidacyPayload(nodes ...*Node) {
+	if len(nodes) == 0 {
 		return
 	}
 
-	for _, node := range d.nodes {
-		if slices.Contains(nodeNames, node.Name) {
-			node.IssueCandidacyPayload = false
-		}
+	for _, node := range nodes {
+		node.IssueCandidacyPayload = false
 	}
 
 	d.DockerComposeUp(true)


### PR DESCRIPTION
Fix race condition when stopping publishing candidate payloads at network startup.
Previously the network started and sometimes candidate payloads were issued before it was stopped in a test, causing committee checks to fail due to selecting different committee than expected.