### PR TITLE
Fix engine switching comittee rotation test

### DIFF
--- a/pkg/protocol/engine/attestation/attestations.go
+++ b/pkg/protocol/engine/attestation/attestations.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/iotaledger/hive.go/ads"
+	"github.com/iotaledger/hive.go/log"
 	"github.com/iotaledger/hive.go/runtime/module"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/blocks"
 	iotago "github.com/iotaledger/iota.go/v4"
@@ -28,6 +29,8 @@ type Attestations interface {
 	Reset()
 
 	RestoreFromDisk() (err error)
+
+	log.Logger
 
 	module.Interface
 }

--- a/pkg/protocol/engine/attestation/slotattestation/manager.go
+++ b/pkg/protocol/engine/attestation/slotattestation/manager.go
@@ -5,6 +5,7 @@ import (
 	"github.com/iotaledger/hive.go/core/memstorage"
 	"github.com/iotaledger/hive.go/ierrors"
 	"github.com/iotaledger/hive.go/kvstore"
+	"github.com/iotaledger/hive.go/lo"
 	"github.com/iotaledger/hive.go/log"
 	"github.com/iotaledger/hive.go/runtime/module"
 	"github.com/iotaledger/hive.go/runtime/syncutils"
@@ -221,6 +222,7 @@ func (m *Manager) applyToPendingAttestations(attestation *iotago.Attestation, cu
 	}
 
 	for i := cutoffSlot; i <= updatedAttestation.Header.SlotCommitmentID.Slot(); i++ {
+		m.LogTrace("Applying attestation", "blockID", lo.PanicOnErr(updatedAttestation.BlockID()), "committing to", updatedAttestation.Header.SlotCommitmentID.Slot(), "pending attestations at slot", i)
 		m.pendingAttestations.Get(i, true).Set(attestation.Header.IssuerID, updatedAttestation)
 	}
 }
@@ -240,7 +242,7 @@ func (m *Manager) Commit(slot iotago.SlotIndex) (newCW uint64, attestationsRoot 
 
 	cutoffSlot, valid := m.computeAttestationCommitmentOffset(slot)
 
-	m.LogTrace("Committing", slot, "cutoffSlot", cutoffSlot)
+	m.LogTrace("Committing", "slot", slot, "cutoffSlot", cutoffSlot)
 
 	// Remove all future attestations of slot and apply to pending attestations window.
 	futureAttestations := m.futureAttestations.Evict(slot)

--- a/pkg/protocol/engine/attestation/slotattestation/testframework_test.go
+++ b/pkg/protocol/engine/attestation/slotattestation/testframework_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/iotaledger/hive.go/kvstore"
 	"github.com/iotaledger/hive.go/kvstore/mapdb"
 	"github.com/iotaledger/hive.go/lo"
+	"github.com/iotaledger/hive.go/log"
 	"github.com/iotaledger/hive.go/runtime/syncutils"
 	"github.com/iotaledger/iota-core/pkg/core/account"
 	"github.com/iotaledger/iota-core/pkg/model"
@@ -76,6 +77,7 @@ func NewTestFramework(test *testing.T) *TestFramework {
 	t.apiProvider = iotago.SingleVersionProvider(t.testAPI)
 
 	t.Instance = slotattestation.NewManager(
+		log.NewLogger(),
 		0,
 		0,
 		bucketedStorage,

--- a/pkg/tests/protocol_engine_switching_test.go
+++ b/pkg/tests/protocol_engine_switching_test.go
@@ -833,7 +833,7 @@ func TestProtocol_EngineSwitching_Tie(t *testing.T) {
 			initialParentsPrefix = "Genesis"
 		}
 
-		ts.IssueBlocksAtSlots(slotPrefix(partition, slots[0]), slots, 4, initialParentsPrefix, targetNodes, true, false)
+		ts.IssueBlocksAtSlots(slotPrefix(partition, slots[0]), slots, 4, initialParentsPrefix, targetNodes, true, true)
 
 		cumulativeAttestations := uint64(0)
 		for slot := genesisSlot + maxCommittableAge; slot <= lastCommittedSlot; slot++ {
@@ -845,7 +845,8 @@ func TestProtocol_EngineSwitching_Tie(t *testing.T) {
 			}
 
 			for _, node := range otherNodes {
-				if slot <= lastCommonSlot+minCommittableAge {
+				// We force the commitments to be at minCommittableAge-1.
+				if slot <= lastCommonSlot+minCommittableAge-1 {
 					attestationBlocks.Add(ts, node, partition, min(slot, lastCommonSlot)) // carry forward last known attestations
 
 					cumulativeAttestations++

--- a/pkg/tests/protocol_engine_switching_test.go
+++ b/pkg/tests/protocol_engine_switching_test.go
@@ -469,6 +469,7 @@ func TestProtocol_EngineSwitching_CommitteeRotation(t *testing.T) {
 			ts.IssueCandidacyAnnouncementInSlot("P0:node2-candidacy:1", 3, "P0:node1-candidacy:1", ts.Wallet("node2"))
 		}
 
+		// Important note: We need to issue with `useMinCommittableAge` set to true, to make sure that the blocks do commit to a deterministic slot, so that we can assert the attestations and how they are carried forward later.
 		ts.IssueBlocksAtSlots("P0:", []iotago.SlotIndex{3, 4, 5, 6, 7}, 4, "P0:node2-candidacy:1", ts.Nodes(), true, true)
 
 		ts.AssertNodeState(ts.Nodes(),
@@ -496,13 +497,16 @@ func TestProtocol_EngineSwitching_CommitteeRotation(t *testing.T) {
 
 	// Issue blocks in partition 1.
 	{
-		ts.IssueBlocksAtSlots("P1:", []iotago.SlotIndex{8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 4, "P0:7.3", nodesP1, true, false)
+		ts.IssueBlocksAtSlots("P1:", []iotago.SlotIndex{8, 9, 10, 11, 12, 13, 14, 15}, 4, "P0:7.3", nodesP1, true, true)
+		// Slot 16 is the new epoch, where node0 is not part of the (online) committee. Therefore, we can't issue blocks with commitments at minCommittableAge anymore.
+		// This is fine, as we keep issuing with the committee members and therefore within each slot there is a newer attestation that replaces the previous one.
+		// However, it is important that Block(P1:15.3-node0) commits to Slot12, as this decides how far we carry the attestation forward.
+		ts.IssueBlocksAtSlots("P1:", []iotago.SlotIndex{16, 17, 18, 19, 20}, 4, "P1:15.3", nodesP1, true, false)
 
 		ts.AssertNodeState(nodesP1,
 			testsuite.WithLatestFinalizedSlot(17),
 			testsuite.WithLatestCommitmentSlotIndex(18),
 			testsuite.WithEqualStoredCommitmentAtIndex(18),
-			testsuite.WithLatestCommitmentCumulativeWeight(47), // 4 + see attestation assertions below for how to compute
 			testsuite.WithSybilProtectionOnlineCommittee(ts.SeatOfNodes(18, "node1", "node2")...),
 			testsuite.WithEvictedSlot(18),
 		)
@@ -524,9 +528,10 @@ func TestProtocol_EngineSwitching_CommitteeRotation(t *testing.T) {
 		ts.AssertAttestationsForSlot(13, ts.Blocks("P1:13.3-node0", "P1:13.3-node1", "P1:13.3-node2"), nodesP1...)             // Committee in epoch 1 is all nodes; node3 is in P2
 		ts.AssertAttestationsForSlot(14, ts.Blocks("P1:14.3-node0", "P1:14.3-node1", "P1:14.3-node2"), nodesP1...)             // Committee in epoch 1 is all nodes; node3 is in P2
 		ts.AssertAttestationsForSlot(15, ts.Blocks("P1:15.3-node0", "P1:15.3-node1", "P1:15.3-node2"), nodesP1...)             // Committee in epoch 1 is all nodes; node3 is in P2
-		ts.AssertAttestationsForSlot(16, ts.Blocks("P1:15.3-node0", "P1:16.3-node1", "P1:16.3-node2"), nodesP1...)             // We're in Epoch 2 (only node1, node2) but we carry attestations of others because of window
-		ts.AssertAttestationsForSlot(17, ts.Blocks("P1:15.3-node0", "P1:17.3-node1", "P1:17.3-node2"), nodesP1...)             // Committee in epoch 2 is only node1, node2
-		ts.AssertAttestationsForSlot(18, ts.Blocks("P1:15.3-node0", "P1:18.3-node1", "P1:18.3-node2"), nodesP1...)             // Committee in epoch 2 is only node1, node2
+		ts.AssertAttestationsForSlot(16, ts.Blocks("P1:15.3-node0", "P1:16.3-node1", "P1:16.3-node2"), nodesP1...)             // We're in Epoch 2 (only node1, node2) but we carry attestations of others because of window (=maxCommittableAge). Block(P1:15.3-node0) commits to Slot12.
+		ts.AssertAttestationsForSlot(17, ts.Blocks("P1:15.3-node0", "P1:17.3-node1", "P1:17.3-node2"), nodesP1...)             // Committee in epoch 2 is only node1, node2. Block(P1:15.3-node0) commits to Slot12.
+		ts.AssertAttestationsForSlot(18, ts.Blocks("P1:18.3-node1", "P1:18.3-node2"), nodesP1...)                              // Committee in epoch 2 is only node1, node2. Block(P1:15.3-node0) commits to Slot12, that's why it is not carried to 18.
+		ts.AssertLatestCommitmentCumulativeWeight(46, nodesP1...)                                                              // 4 + see attestation assertions above for how to compute
 
 		ts.AssertStrongTips(ts.Blocks("P1:20.3-node0", "P1:20.3-node1", "P1:20.3-node2"), nodesP1...)
 
@@ -537,12 +542,12 @@ func TestProtocol_EngineSwitching_CommitteeRotation(t *testing.T) {
 	// Issue blocks in partition 2.
 	{
 		ts.IssueBlocksAtSlots("P2:", []iotago.SlotIndex{8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 4, "P0:7.3", nodesP2, true, false)
+		// Here we keep issuing with the only (online) validator in the partition. Since we issue in each slot, we don't need to set `useCommitmentAtMinCommittableAge` to true, as the newer blocks/attestations in each slot replace the previous ones.
 
 		ts.AssertNodeState(nodesP2,
 			testsuite.WithLatestFinalizedSlot(4),
 			testsuite.WithLatestCommitmentSlotIndex(18),
 			testsuite.WithEqualStoredCommitmentAtIndex(18),
-			// testsuite.WithLatestCommitmentCumulativeWeight(43), // 4 + see attestation assertions below for how to compute
 			testsuite.WithSybilProtectionOnlineCommittee(ts.SeatOfNodes(18, "node3")...),
 			testsuite.WithEvictedSlot(18),
 		)
@@ -566,6 +571,8 @@ func TestProtocol_EngineSwitching_CommitteeRotation(t *testing.T) {
 		ts.AssertAttestationsForSlot(15, ts.Blocks("P2:15.3-node3"), nodesP2...)                                               // Committee in epoch 1 is all nodes; only node3 is in P2
 		ts.AssertAttestationsForSlot(16, ts.Blocks("P2:16.3-node3"), nodesP2...)                                               // Committee in epoch 2 (reused) is all nodes; only node3 is in P2
 		ts.AssertAttestationsForSlot(17, ts.Blocks("P2:17.3-node3"), nodesP2...)                                               // Committee in epoch 2 (reused) is all nodes; only node3 is in P2
+		ts.AssertAttestationsForSlot(18, ts.Blocks("P2:18.3-node3"), nodesP2...)                                               // Committee in epoch 2 (reused) is all nodes; only node3 is in P2
+		ts.AssertLatestCommitmentCumulativeWeight(29, nodesP2...)                                                              // 4 + see attestation assertions above for how to compute
 
 		ts.AssertStrongTips(ts.Blocks("P2:20.3-node3"), nodesP2...)
 
@@ -639,9 +646,9 @@ func TestProtocol_EngineSwitching_CommitteeRotation(t *testing.T) {
 	ts.AssertAttestationsForSlot(13, ts.Blocks("P1:13.3-node0", "P1:13.3-node1", "P1:13.3-node2"), ts.Nodes()...)             // Committee in epoch 1 is all nodes; node3 is in P2
 	ts.AssertAttestationsForSlot(14, ts.Blocks("P1:14.3-node0", "P1:14.3-node1", "P1:14.3-node2"), ts.Nodes()...)             // Committee in epoch 1 is all nodes; node3 is in P2
 	ts.AssertAttestationsForSlot(15, ts.Blocks("P1:15.3-node0", "P1:15.3-node1", "P1:15.3-node2"), ts.Nodes()...)             // Committee in epoch 1 is all nodes; node3 is in P2
-	ts.AssertAttestationsForSlot(16, ts.Blocks("P1:15.3-node0", "P1:16.3-node1", "P1:16.3-node2"), ts.Nodes()...)             // We're in Epoch 2 (only node1, node2) but we carry attestations of others because of window
-	ts.AssertAttestationsForSlot(17, ts.Blocks("P1:15.3-node0", "P1:17.3-node1", "P1:17.3-node2"), ts.Nodes()...)             // We're in Epoch 2 (only node1, node2) but we carry attestations of others because of window
-	ts.AssertAttestationsForSlot(18, ts.Blocks("P1:15.3-node0", "P1:18.3-node1", "P1:18.3-node2"), ts.Nodes()...)             // We're in Epoch 2 (only node1, node2) but we carry attestations of others because of window
+	ts.AssertAttestationsForSlot(16, ts.Blocks("P1:15.3-node0", "P1:16.3-node1", "P1:16.3-node2"), nodesP1...)                // We're in Epoch 2 (only node1, node2) but we carry attestations of others because of window (=maxCommittableAge). Block(P1:15.3-node0) commits to Slot12.
+	ts.AssertAttestationsForSlot(17, ts.Blocks("P1:15.3-node0", "P1:17.3-node1", "P1:17.3-node2"), nodesP1...)                // Committee in epoch 2 is only node1, node2. Block(P1:15.3-node0) commits to Slot12.
+	ts.AssertAttestationsForSlot(18, ts.Blocks("P1:18.3-node1", "P1:18.3-node2"), nodesP1...)                                 // Committee in epoch 2 is only node1, node2. Block(P1:15.3-node0) commits to Slot12, that's why it is not carried to 18.
 	ts.AssertAttestationsForSlot(19, ts.Blocks("P1:19.3-node1", "P1:19.3-node2"), ts.Nodes()...)                              // Committee in epoch 2 is only node1, node2
 }
 

--- a/pkg/testsuite/attestations.go
+++ b/pkg/testsuite/attestations.go
@@ -37,15 +37,15 @@ func (t *TestSuite) AssertAttestationsForSlot(slot iotago.SlotIndex, blocks []*b
 				return nil
 			})
 			if err != nil {
-				return ierrors.Wrapf(err, "AssertAttestationsForSlot: %s: error iterating over attestation tree", node.Name)
+				return ierrors.Wrapf(err, "AssertAttestationsForSlot: %s: %s error iterating over attestation tree", node.Name, slot)
 			}
 
 			if !assert.ElementsMatch(t.fakeTesting, expectedAttestations, storedAttestations) {
-				return ierrors.Errorf("AssertAttestationsForSlot: %s: expected attestation(s) %s, got %s", node.Name, expectedAttestations, storedAttestations)
+				return ierrors.Errorf("AssertAttestationsForSlot: %s: %s expected attestation(s) %s, got %s", node.Name, slot, expectedAttestations, storedAttestations)
 			}
 
 			if len(expectedAttestations) != len(storedAttestations) {
-				return ierrors.Errorf("AssertAttestationsForSlot: %s: expected %d attestation(s), got %d", node.Name, len(expectedAttestations), len(storedAttestations))
+				return ierrors.Errorf("AssertAttestationsForSlot: %s: %s expected %d attestation(s), got %d", node.Name, slot, len(expectedAttestations), len(storedAttestations))
 			}
 
 			return nil


### PR DESCRIPTION
Fixes #683. 

This was a hard nut to track down. Turned out in the end that the test wasn't correct and left some room for blocks committing to different slots. Usually, this is not a big problem, especially if committee members keep issuing in following slots, as this effectively creates new attestations for the slots. However, in this specific case, it did make a difference to what a particular block committed as the validator ceased to be a committee member and its attestations are carried forward `maxCommittbleAge` slots. 