### PR TITLE
Adapt faucet mana limits

### DIFF
--- a/deploy/ansible/roles/iota-core-node/templates/docker-compose-iota-core.yml.j2
+++ b/deploy/ansible/roles/iota-core-node/templates/docker-compose-iota-core.yml.j2
@@ -128,9 +128,12 @@ services:
     command: >
       --inx.address=iota-core:9029
       --faucet.bindAddress=0.0.0.0:8091
-      --faucet.manaAmount=100000000
+      --faucet.rateLimit.enabled=true
       --faucet.baseTokenAmount=1000000000000
-      --faucet.baseTokenAmountMaxTarget=100000000000000
+      --faucet.baseTokenAmountSmall=100000000000
+      --faucet.baseTokenAmountMaxTarget=5000000000000
+      --faucet.manaAmount=100000000
+      --faucet.manaAmountMinFaucet=1000000000
 {% endif %}
 
 {% if 'node-01' in inventory_hostname or 'node-02' in inventory_hostname or 'node-03' in inventory_hostname %}

--- a/tools/docker-network/docker-compose.yml
+++ b/tools/docker-network/docker-compose.yml
@@ -282,6 +282,11 @@ services:
       --inx.address=node-1-validator:9029
       --faucet.bindAddress=inx-faucet:8091
       --faucet.rateLimit.enabled=false
+      --faucet.baseTokenAmount=1000000000
+      --faucet.baseTokenAmountSmall=100000000
+      --faucet.baseTokenAmountMaxTarget=5000000000
+      --faucet.manaAmount=10000000
+      --faucet.manaAmountMinFaucet=100000000
 
   inx-validator-1:
     image: iotaledger/inx-validator:1.0-alpha

--- a/tools/genesis-snapshot/presets/presets.go
+++ b/tools/genesis-snapshot/presets/presets.go
@@ -158,7 +158,7 @@ var (
 			snapshotcreator.BasicOutputDetails{
 				Address: lo.Return2(iotago.ParseBech32("rms1xqqz7e8e69uej86s2s4srcp5lgzrkx25qwr4hpnha7h3j66pezyq85qpqg55v3ur")),
 				Amount:  1_000_000_000_000_000,
-				Mana:    10_000_000,
+				Mana:    1_000_000_000_000_000,
 			},
 		),
 	}
@@ -278,7 +278,7 @@ var (
 			snapshotcreator.BasicOutputDetails{
 				Address: lo.Return2(iotago.ParseBech32("rms1xqqy3txhvnmzv53kgm2ueu30splfd5ct02cqvnehpdn04qgeskv9a3qpqgrhlhv3")),
 				Amount:  1_000_000_000_000_000,
-				Mana:    10_000_000,
+				Mana:    1_000_000_000_000_000,
 			},
 		),
 	}


### PR DESCRIPTION
With the new workscore parameters in https://github.com/iotaledger/iota.go/pull/680 we also need to adapt the faucet limits, otherwise all the tests take some time to acquire mana first to send a single tx.