### PR TITLE
Allot more mana at account creation in docker test

### DIFF
--- a/tools/docker-network/tests/dockerframework.go
+++ b/tools/docker-network/tests/dockerframework.go
@@ -381,10 +381,14 @@ func (d *DockerTestFramework) CreateAccount(opts ...options.Option[builder.Accou
 	// make sure an implicit account is committed
 	d.CheckAccountStatus(ctx, iotago.EmptyBlockID, implicitOutputID.TransactionID(), implicitOutputID, accountAddress)
 
+	// request a faucet funds to gain enough BIC for the account
+	fundsAddr, privateKey := d.getAddress(iotago.AddressEd25519)
+	fundsOutputID, fundsUTXOOutput := d.RequestFaucetFunds(ctx, fundsAddr)
+
 	// transition to a full account with new Ed25519 address and staking feature
 	accEd25519Addr, accPrivateKey := d.getAddress(iotago.AddressEd25519)
 	accBlockIssuerKey := iotago.Ed25519PublicKeyHashBlockIssuerKeyFromPublicKey(hiveEd25519.PublicKey(accPrivateKey.Public().(ed25519.PublicKey)))
-	accountOutput := options.Apply(builder.NewAccountOutputBuilder(accEd25519Addr, implicitAccountOutput.BaseTokenAmount()),
+	accountOutput := options.Apply(builder.NewAccountOutputBuilder(accEd25519Addr, implicitAccountOutput.BaseTokenAmount()+fundsUTXOOutput.BaseTokenAmount()),
 		opts, func(b *builder.AccountOutputBuilder) {
 			b.AccountID(accountID).
 				BlockIssuer(iotago.NewBlockIssuerKeys(accBlockIssuerKey), iotago.MaxSlotIndex)
@@ -400,8 +404,13 @@ func (d *DockerTestFramework) CreateAccount(opts ...options.Option[builder.Accou
 	congestionResp, err := clt.Congestion(ctx, accountAddress, 0, lo.PanicOnErr(issuerResp.LatestCommitment.ID()))
 	require.NoError(d.Testing, err)
 
-	implicitAddrSigner := iotago.NewInMemoryAddressSigner(iotago.NewAddressKeysForImplicitAccountCreationAddress(receiverAddr.(*iotago.ImplicitAccountCreationAddress), implicitPrivateKey))
+	implicitAddrSigner := iotago.NewInMemoryAddressSigner(iotago.NewAddressKeysForImplicitAccountCreationAddress(receiverAddr.(*iotago.ImplicitAccountCreationAddress), implicitPrivateKey), iotago.NewAddressKeysForEd25519Address(fundsAddr.(*iotago.Ed25519Address), privateKey))
 	signedTx, err := builder.NewTransactionBuilder(apiForSlot).
+		AddInput(&builder.TxInput{
+			UnlockTarget: fundsAddr,
+			InputID:      fundsOutputID,
+			Input:        fundsUTXOOutput,
+		}).
 		AddInput(&builder.TxInput{
 			UnlockTarget: receiverAddr,
 			InputID:      implicitOutputID,

--- a/tools/docker-network/tests/dockerframework.go
+++ b/tools/docker-network/tests/dockerframework.go
@@ -487,6 +487,47 @@ func (d *DockerTestFramework) DelegateToValidator(from *Account, validator *Node
 	return delegationOutput.StartEpoch
 }
 
+// IncreaseBIC requests faucet funds then uses it to allots mana to an account.
+func (d *DockerTestFramework) IncreaseBIC(to *Account) {
+	// requesting faucet funds for allotment
+	ctx := context.TODO()
+	fundsAddr, privateKey := d.getAddress(iotago.AddressEd25519)
+	fundsOutputID, fundsUTXOOutput := d.RequestFaucetFunds(ctx, fundsAddr)
+	fundsAddrSigner := iotago.NewInMemoryAddressSigner(iotago.NewAddressKeysForEd25519Address(fundsAddr.(*iotago.Ed25519Address), privateKey))
+
+	clt := d.Node("V1").Client
+	currentSlot := clt.LatestAPI().TimeProvider().SlotFromTime(time.Now())
+	apiForSlot := clt.APIForSlot(currentSlot)
+
+	issuerResp, err := clt.BlockIssuance(ctx)
+	require.NoError(d.Testing, err)
+
+	congestionResp, err := clt.Congestion(ctx, to.AccountAddress, 0, lo.PanicOnErr(issuerResp.LatestCommitment.ID()))
+	require.NoError(d.Testing, err)
+
+	basicOutput, err := builder.NewBasicOutputBuilder(fundsAddr, fundsUTXOOutput.BaseTokenAmount()).Build()
+	require.NoError(d.Testing, err)
+
+	signedTx, err := builder.NewTransactionBuilder(apiForSlot).
+		AddInput(&builder.TxInput{
+			UnlockTarget: fundsAddr,
+			InputID:      fundsOutputID,
+			Input:        fundsUTXOOutput,
+		}).
+		AddOutput(basicOutput).
+		AllotAllMana(currentSlot, to.AccountID, 0).
+		Build(fundsAddrSigner)
+
+	blkID := d.SubmitPayload(ctx, signedTx, wallet.NewEd25519Account(to.AccountID, to.BlockIssuerKey), congestionResp, issuerResp)
+
+	fmt.Println("Allot mana transaction sent, blkID:", blkID.ToHex(), ", txID:", lo.PanicOnErr(signedTx.Transaction.ID()).ToHex(), ", slot:", blkID.Slot())
+
+	d.AwaitTransactionPayloadAccepted(ctx, blkID)
+
+	// wait until BIC is updated
+	d.AwaitCommitment(blkID.Slot())
+}
+
 // AllotManaTo requests faucet funds then uses it to allots mana from one account to another.
 func (d *DockerTestFramework) AllotManaTo(from *Account, to *Account, manaToAllot iotago.Mana) {
 	// requesting faucet funds for allotment


### PR DESCRIPTION
`Test_Delegation` and `Test_AccountTransitions` failed because the account ran out of BIC, which became negative after issuing account transition transaction.

The solution is to request faucet funds and then include it in the account transition transaction, which gives more mana to allot to the account.

`IncreaseBIC` is added to the docker TestFramework, it is used to gain more BIC from faucet to an account. Could be useful for further testing.