### PR TITLE
Refactor presets so they can be reused for docker network tests

### DIFF
--- a/tools/docker-network/tests/options.go
+++ b/tools/docker-network/tests/options.go
@@ -5,16 +5,11 @@ package tests
 import (
 	"time"
 
-	"golang.org/x/crypto/blake2b"
-
-	"github.com/iotaledger/hive.go/crypto/ed25519"
-	"github.com/iotaledger/hive.go/lo"
 	"github.com/iotaledger/hive.go/runtime/options"
-	"github.com/iotaledger/iota-core/pkg/testsuite/mock"
 	"github.com/iotaledger/iota-core/pkg/testsuite/snapshotcreator"
+	"github.com/iotaledger/iota-core/tools/genesis-snapshot/presets"
 	iotago "github.com/iotaledger/iota.go/v4"
 	"github.com/iotaledger/iota.go/v4/builder"
-	"github.com/iotaledger/iota.go/v4/hexutil"
 )
 
 var DefaultProtocolParametersOptions = []options.Option[iotago.V3ProtocolParameters]{
@@ -24,122 +19,9 @@ var DefaultProtocolParametersOptions = []options.Option[iotago.V3ProtocolParamet
 // DefaultSnapshotOptions are the default snapshot options for the docker network.
 func DefaultAccountOptions(protocolParams *iotago.V3ProtocolParameters) []options.Option[snapshotcreator.Options] {
 	return []options.Option[snapshotcreator.Options]{
-		snapshotcreator.WithAccounts(
-			snapshotcreator.AccountDetails{
-				/*
-					node-01-validator
-
-					Ed25519 Public Key:   293dc170d9a59474e6d81cfba7f7d924c09b25d7166bcfba606e53114d0a758b
-					Ed25519 Address:      rms1qzg8cqhfxqhq7pt37y8cs4v5u4kcc48lquy2k73ehsdhf5ukhya3ytgk0ny
-					Account Address:      rms1pzg8cqhfxqhq7pt37y8cs4v5u4kcc48lquy2k73ehsdhf5ukhya3y5rx2w6
-					Restricted Address:   rms1xqqfqlqzayczurc9w8cslzz4jnjkmrz5lurs32m68x7pkaxnj6unkyspqg8mulpm, Capabilities: mana
-				*/
-				AccountID:            blake2b.Sum256(lo.PanicOnErr(hexutil.DecodeHex("0x293dc170d9a59474e6d81cfba7f7d924c09b25d7166bcfba606e53114d0a758b"))),
-				Address:              iotago.Ed25519AddressFromPubKey(lo.PanicOnErr(hexutil.DecodeHex("0x293dc170d9a59474e6d81cfba7f7d924c09b25d7166bcfba606e53114d0a758b"))),
-				Amount:               mock.MinValidatorAccountAmount(protocolParams),
-				IssuerKey:            iotago.Ed25519PublicKeyHashBlockIssuerKeyFromPublicKey(ed25519.PublicKey(lo.PanicOnErr(hexutil.DecodeHex("0x293dc170d9a59474e6d81cfba7f7d924c09b25d7166bcfba606e53114d0a758b")))),
-				ExpirySlot:           iotago.MaxSlotIndex,
-				BlockIssuanceCredits: iotago.MaxBlockIssuanceCredits / 5,
-				StakingEndEpoch:      iotago.MaxEpochIndex,
-				FixedCost:            1,
-				StakedAmount:         mock.MinValidatorAccountAmount(protocolParams) + 13,
-				Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protocolParams)),
-			},
-			snapshotcreator.AccountDetails{
-				/*
-					node-02-validator
-
-					Ed25519 Public Key:   05c1de274451db8de8182d64c6ee0dca3ae0c9077e0b4330c976976171d79064
-					Ed25519 Address:      rms1qqm4xk8e9ny5w5rxjkvtp249tfhlwvcshyr3pc0665jvp7g3hc875flpz2p
-					Account Address:      rms1pqm4xk8e9ny5w5rxjkvtp249tfhlwvcshyr3pc0665jvp7g3hc875k538hl
-					Restricted Address:   rms1xqqrw56clykvj36sv62e3v9254dxlaenzzuswy8plt2jfs8ezxlql6spqgkulf7u, Capabilities: mana
-				*/
-				AccountID:            blake2b.Sum256(lo.PanicOnErr(hexutil.DecodeHex("0x05c1de274451db8de8182d64c6ee0dca3ae0c9077e0b4330c976976171d79064"))),
-				Address:              iotago.Ed25519AddressFromPubKey(lo.PanicOnErr(hexutil.DecodeHex("0x05c1de274451db8de8182d64c6ee0dca3ae0c9077e0b4330c976976171d79064"))),
-				Amount:               mock.MinValidatorAccountAmount(protocolParams),
-				IssuerKey:            iotago.Ed25519PublicKeyHashBlockIssuerKeyFromPublicKey(ed25519.PublicKey(lo.PanicOnErr(hexutil.DecodeHex("0x05c1de274451db8de8182d64c6ee0dca3ae0c9077e0b4330c976976171d79064")))),
-				ExpirySlot:           iotago.MaxSlotIndex,
-				BlockIssuanceCredits: iotago.MaxBlockIssuanceCredits / 5,
-				StakingEndEpoch:      iotago.MaxEpochIndex,
-				FixedCost:            1,
-				StakedAmount:         mock.MinValidatorAccountAmount(protocolParams) + 12,
-				Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protocolParams)),
-			},
-			snapshotcreator.AccountDetails{
-				/*
-					node-03-validator
-
-					Ed25519 Public Key:   1e4b21eb51dcddf65c20db1065e1f1514658b23a3ddbf48d30c0efc926a9a648
-					Ed25519 Address:      rms1qp4wuuz0y42caz48vv876qfpmffswsvg40zz8v79sy8cp0jfxm4kuvz0a44
-					Account Address:      rms1pp4wuuz0y42caz48vv876qfpmffswsvg40zz8v79sy8cp0jfxm4kunflcgt
-					Restricted Address:   rms1xqqx4mnsfuj4tr525a3slmgpy8d9xp6p3z4ugganckqslq97fymwkmspqgnzrkjq, Capabilities: mana
-				*/
-				AccountID:            blake2b.Sum256(lo.PanicOnErr(hexutil.DecodeHex("0x1e4b21eb51dcddf65c20db1065e1f1514658b23a3ddbf48d30c0efc926a9a648"))),
-				Address:              iotago.Ed25519AddressFromPubKey(lo.PanicOnErr(hexutil.DecodeHex("0x1e4b21eb51dcddf65c20db1065e1f1514658b23a3ddbf48d30c0efc926a9a648"))),
-				Amount:               mock.MinValidatorAccountAmount(protocolParams),
-				IssuerKey:            iotago.Ed25519PublicKeyHashBlockIssuerKeyFromPublicKey(ed25519.PublicKey(lo.PanicOnErr(hexutil.DecodeHex("0x1e4b21eb51dcddf65c20db1065e1f1514658b23a3ddbf48d30c0efc926a9a648")))),
-				ExpirySlot:           iotago.MaxSlotIndex,
-				BlockIssuanceCredits: iotago.MaxBlockIssuanceCredits / 5,
-				StakingEndEpoch:      iotago.MaxEpochIndex,
-				FixedCost:            1,
-				StakedAmount:         mock.MinValidatorAccountAmount(protocolParams) + 5,
-				Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protocolParams)),
-			},
-			snapshotcreator.AccountDetails{
-				/*
-					node-04-validator
-
-					Ed25519 Public Key:   c9ceac37d293155a578381aa313ee74edfa3ac73ee930d045564aae7771e8ffe
-					Private Key: 5cceed8ca18146639330177ab4f61ab1a71e2d3fea3d4389f9e2e43f34ec8b33c9ceac37d293155a578381aa313ee74edfa3ac73ee930d045564aae7771e8ffe
-					Account Address:      rms1pr8cxs3dzu9xh4cduff4dd4cxdthpjkpwmz2244f75m0urslrsvtsshrrjw
-					Ed25519 Address:      rms1qr8cxs3dzu9xh4cduff4dd4cxdthpjkpwmz2244f75m0urslrsvts0unx0s
-					Restricted Address:   rms1xqyvnn4vxlffx92627pcr2338mn5ahar43e7aycdq32kf2h8wu0gllspqgz9eyua, Capabilities: mana
-				*/
-				AccountID:            blake2b.Sum256(lo.PanicOnErr(hexutil.DecodeHex("0xc9ceac37d293155a578381aa313ee74edfa3ac73ee930d045564aae7771e8ffe"))),
-				Address:              iotago.Ed25519AddressFromPubKey(lo.PanicOnErr(hexutil.DecodeHex("0xc9ceac37d293155a578381aa313ee74edfa3ac73ee930d045564aae7771e8ffe"))),
-				Amount:               mock.MinValidatorAccountAmount(protocolParams),
-				IssuerKey:            iotago.Ed25519PublicKeyHashBlockIssuerKeyFromPublicKey(ed25519.PublicKey(lo.PanicOnErr(hexutil.DecodeHex("0xc9ceac37d293155a578381aa313ee74edfa3ac73ee930d045564aae7771e8ffe")))),
-				ExpirySlot:           iotago.MaxSlotIndex,
-				BlockIssuanceCredits: iotago.MaxBlockIssuanceCredits / 5,
-				StakingEndEpoch:      iotago.MaxEpochIndex,
-				FixedCost:            1,
-				StakedAmount:         mock.MinValidatorAccountAmount(protocolParams),
-				Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protocolParams)),
-			},
-			snapshotcreator.AccountDetails{
-				/*
-					inx-blockissuer
-
-					Ed25519 Private Key:  432c624ca3260f910df35008d5c740593b222f1e196e6cdb8cd1ad080f0d4e33997be92a22b1933f36e26fba5f721756f95811d6b4ae21564197c2bfa4f28270
-					Ed25519 Public Key:   997be92a22b1933f36e26fba5f721756f95811d6b4ae21564197c2bfa4f28270
-					Ed25519 Address:      rms1qrkursay9fs2qjmfctamd6yxg9x8r3ry47786x0mvwek4qr9xd9d583cnpd
-					Account Address:      rms1prkursay9fs2qjmfctamd6yxg9x8r3ry47786x0mvwek4qr9xd9d5c6gkun
-					Restricted Address:   rms1xqqwmswr5s4xpgztd8p0hdhgseq5cuwyvjhmclgeld3mx65qv5e54kspqgda0nrn, Capabilities: mana
-				*/
-				AccountID:            blake2b.Sum256(lo.PanicOnErr(hexutil.DecodeHex("0x997be92a22b1933f36e26fba5f721756f95811d6b4ae21564197c2bfa4f28270"))),
-				Address:              iotago.Ed25519AddressFromPubKey(lo.PanicOnErr(hexutil.DecodeHex("0x997be92a22b1933f36e26fba5f721756f95811d6b4ae21564197c2bfa4f28270"))),
-				Amount:               mock.MinIssuerAccountAmount(protocolParams),
-				IssuerKey:            iotago.Ed25519PublicKeyHashBlockIssuerKeyFromPublicKey(ed25519.PublicKey(lo.PanicOnErr(hexutil.DecodeHex("0x997be92a22b1933f36e26fba5f721756f95811d6b4ae21564197c2bfa4f28270")))),
-				ExpirySlot:           iotago.MaxSlotIndex,
-				BlockIssuanceCredits: iotago.MaxBlockIssuanceCredits / 5,
-				Mana:                 iotago.Mana(mock.MinIssuerAccountAmount(protocolParams)),
-			},
-		),
-		snapshotcreator.WithBasicOutputs(
-			/*
-				inx-faucet
-
-				Ed25519 Private Key:  de52b9964dda96564e9fab362ab16c2669c715c6a2a853bece8a25fc58c599755b938327ea463e0c323c0fd44f6fc1843ed94daecc6909c6043d06b7152e4737
-				Ed25519 Public Key:   5b938327ea463e0c323c0fd44f6fc1843ed94daecc6909c6043d06b7152e4737
-				Ed25519 Address:      rms1qqhkf7w30xv375z59vq7qd86qsa3j4qrsadcval04uvkkswg3qpaqf4hga2
-				Restricted Address:   rms1xqqz7e8e69uej86s2s4srcp5lgzrkx25qwr4hpnha7h3j66pezyq85qpqg55v3ur, Capabilities: mana
-			*/
-			snapshotcreator.BasicOutputDetails{
-				Address: lo.Return2(iotago.ParseBech32("rms1xqqz7e8e69uej86s2s4srcp5lgzrkx25qwr4hpnha7h3j66pezyq85qpqg55v3ur")),
-				Amount:  1_000_000_000_000_000,
-				Mana:    10_000_000,
-			},
-		)}
+		snapshotcreator.WithAccounts(presets.AccountsDockerFunc(protocolParams)...),
+		snapshotcreator.WithBasicOutputs(presets.BasicOutputsDocker...),
+	}
 }
 
 func WithFaucetURL(url string) options.Option[DockerTestFramework] {

--- a/tools/genesis-snapshot/main.go
+++ b/tools/genesis-snapshot/main.go
@@ -16,7 +16,7 @@ import (
 
 func main() {
 	parsedOpts, configSelected := parseFlags()
-	opts := presets.Base
+	opts := presets.SnapshotOptionsBase
 	if strings.Contains(configSelected, ".yml") {
 		yamlOpts, err := presets.GenerateFromYaml(configSelected)
 		if err != nil {
@@ -26,9 +26,9 @@ func main() {
 	} else {
 		switch configSelected {
 		case "docker":
-			opts = append(opts, presets.Docker...)
+			opts = append(opts, presets.SnapshotOptionsDocker...)
 		case "feature":
-			opts = append(opts, presets.Feature...)
+			opts = append(opts, presets.SnapshotOptionsFeature...)
 		default:
 			configSelected = "default"
 		}

--- a/tools/genesis-snapshot/presets/presets.go
+++ b/tools/genesis-snapshot/presets/presets.go
@@ -17,37 +17,28 @@ import (
 
 var (
 	// use defaults from iota.go.
-	protocolParamsBase = iotago.NewV3SnapshotProtocolParameters(
+	ProtocolParamsBase = iotago.NewV3SnapshotProtocolParameters(
 		iotago.WithNetworkOptions("default", iotago.PrefixTestnet),
 	)
 
 	// use defaults from iota.go.
-	protocolParamsDocker = iotago.NewV3SnapshotProtocolParameters(
+	ProtocolParamsDocker = iotago.NewV3SnapshotProtocolParameters(
 		iotago.WithNetworkOptions("docker", iotago.PrefixTestnet),
 		iotago.WithTimeProviderOptions(5, time.Now().Unix(), 10, 13),
 		iotago.WithLivenessOptions(10, 15, 3, 6, 8),
 	)
 
 	// use defaults from iota.go.
-	protocolParamsFeature = iotago.NewV3SnapshotProtocolParameters(
+	ProtocolParamsFeature = iotago.NewV3SnapshotProtocolParameters(
 		iotago.WithNetworkOptions("feature", iotago.PrefixTestnet),
 		iotago.WithTimeProviderOptions(666666, time.Now().Unix()-100_000, 10, 13),
 	)
 )
 
 var (
-	Base = []options.Option[snapshotcreator.Options]{
-		snapshotcreator.WithDatabaseVersion(protocol.DatabaseVersion),
-		snapshotcreator.WithFilePath("snapshot.bin"),
-		snapshotcreator.WithProtocolParameters(protocolParamsBase),
-		snapshotcreator.WithAddGenesisRootBlock(true),
-	}
-
-	Docker = []options.Option[snapshotcreator.Options]{
-		snapshotcreator.WithFilePath("docker-network.snapshot"),
-		snapshotcreator.WithProtocolParameters(protocolParamsDocker),
-		snapshotcreator.WithAccounts(
-			snapshotcreator.AccountDetails{
+	AccountsDockerFunc = func(protoParams iotago.ProtocolParameters) []snapshotcreator.AccountDetails {
+		return []snapshotcreator.AccountDetails{
+			{
 				/*
 					node-01-validator
 
@@ -58,16 +49,16 @@ var (
 				*/
 				AccountID:            blake2b.Sum256(lo.PanicOnErr(hexutil.DecodeHex("0x293dc170d9a59474e6d81cfba7f7d924c09b25d7166bcfba606e53114d0a758b"))),
 				Address:              iotago.Ed25519AddressFromPubKey(lo.PanicOnErr(hexutil.DecodeHex("0x293dc170d9a59474e6d81cfba7f7d924c09b25d7166bcfba606e53114d0a758b"))),
-				Amount:               mock.MinValidatorAccountAmount(protocolParamsDocker),
+				Amount:               mock.MinValidatorAccountAmount(protoParams),
 				IssuerKey:            iotago.Ed25519PublicKeyHashBlockIssuerKeyFromPublicKey(ed25519.PublicKey(lo.PanicOnErr(hexutil.DecodeHex("0x293dc170d9a59474e6d81cfba7f7d924c09b25d7166bcfba606e53114d0a758b")))),
 				ExpirySlot:           iotago.MaxSlotIndex,
 				BlockIssuanceCredits: iotago.MaxBlockIssuanceCredits / 5,
 				StakingEndEpoch:      iotago.MaxEpochIndex,
 				FixedCost:            1,
-				StakedAmount:         mock.MinValidatorAccountAmount(protocolParamsDocker),
-				Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protocolParamsDocker)),
+				StakedAmount:         mock.MinValidatorAccountAmount(protoParams),
+				Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protoParams)),
 			},
-			snapshotcreator.AccountDetails{
+			{
 				/*
 					node-02-validator
 
@@ -78,16 +69,16 @@ var (
 				*/
 				AccountID:            blake2b.Sum256(lo.PanicOnErr(hexutil.DecodeHex("0x05c1de274451db8de8182d64c6ee0dca3ae0c9077e0b4330c976976171d79064"))),
 				Address:              iotago.Ed25519AddressFromPubKey(lo.PanicOnErr(hexutil.DecodeHex("0x05c1de274451db8de8182d64c6ee0dca3ae0c9077e0b4330c976976171d79064"))),
-				Amount:               mock.MinValidatorAccountAmount(protocolParamsDocker),
+				Amount:               mock.MinValidatorAccountAmount(protoParams),
 				IssuerKey:            iotago.Ed25519PublicKeyHashBlockIssuerKeyFromPublicKey(ed25519.PublicKey(lo.PanicOnErr(hexutil.DecodeHex("0x05c1de274451db8de8182d64c6ee0dca3ae0c9077e0b4330c976976171d79064")))),
 				ExpirySlot:           iotago.MaxSlotIndex,
 				BlockIssuanceCredits: iotago.MaxBlockIssuanceCredits / 5,
 				StakingEndEpoch:      iotago.MaxEpochIndex,
 				FixedCost:            1,
-				StakedAmount:         mock.MinValidatorAccountAmount(protocolParamsDocker),
-				Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protocolParamsDocker)),
+				StakedAmount:         mock.MinValidatorAccountAmount(protoParams),
+				Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protoParams)),
 			},
-			snapshotcreator.AccountDetails{
+			{
 				/*
 					node-03-validator
 
@@ -98,16 +89,16 @@ var (
 				*/
 				AccountID:            blake2b.Sum256(lo.PanicOnErr(hexutil.DecodeHex("0x1e4b21eb51dcddf65c20db1065e1f1514658b23a3ddbf48d30c0efc926a9a648"))),
 				Address:              iotago.Ed25519AddressFromPubKey(lo.PanicOnErr(hexutil.DecodeHex("0x1e4b21eb51dcddf65c20db1065e1f1514658b23a3ddbf48d30c0efc926a9a648"))),
-				Amount:               mock.MinValidatorAccountAmount(protocolParamsDocker),
+				Amount:               mock.MinValidatorAccountAmount(protoParams),
 				IssuerKey:            iotago.Ed25519PublicKeyHashBlockIssuerKeyFromPublicKey(ed25519.PublicKey(lo.PanicOnErr(hexutil.DecodeHex("0x1e4b21eb51dcddf65c20db1065e1f1514658b23a3ddbf48d30c0efc926a9a648")))),
 				ExpirySlot:           iotago.MaxSlotIndex,
 				BlockIssuanceCredits: iotago.MaxBlockIssuanceCredits / 5,
 				StakingEndEpoch:      iotago.MaxEpochIndex,
 				FixedCost:            1,
-				StakedAmount:         mock.MinValidatorAccountAmount(protocolParamsDocker),
-				Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protocolParamsDocker)),
+				StakedAmount:         mock.MinValidatorAccountAmount(protoParams),
+				Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protoParams)),
 			},
-			snapshotcreator.AccountDetails{
+			{
 				/*
 					node-04-validator
 
@@ -119,16 +110,16 @@ var (
 				*/
 				AccountID:            blake2b.Sum256(lo.PanicOnErr(hexutil.DecodeHex("0xc9ceac37d293155a578381aa313ee74edfa3ac73ee930d045564aae7771e8ffe"))),
 				Address:              iotago.Ed25519AddressFromPubKey(lo.PanicOnErr(hexutil.DecodeHex("0xc9ceac37d293155a578381aa313ee74edfa3ac73ee930d045564aae7771e8ffe"))),
-				Amount:               mock.MinValidatorAccountAmount(protocolParamsDocker),
+				Amount:               mock.MinValidatorAccountAmount(protoParams),
 				IssuerKey:            iotago.Ed25519PublicKeyHashBlockIssuerKeyFromPublicKey(ed25519.PublicKey(lo.PanicOnErr(hexutil.DecodeHex("0xc9ceac37d293155a578381aa313ee74edfa3ac73ee930d045564aae7771e8ffe")))),
 				ExpirySlot:           iotago.MaxSlotIndex,
 				BlockIssuanceCredits: iotago.MaxBlockIssuanceCredits / 5,
 				StakingEndEpoch:      iotago.MaxEpochIndex,
 				FixedCost:            1,
-				StakedAmount:         mock.MinValidatorAccountAmount(protocolParamsDocker),
-				Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protocolParamsDocker)),
+				StakedAmount:         mock.MinValidatorAccountAmount(protoParams),
+				Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protoParams)),
 			},
-			snapshotcreator.AccountDetails{
+			{
 				/*
 					inx-blockissuer
 
@@ -140,36 +131,18 @@ var (
 				*/
 				AccountID:            blake2b.Sum256(lo.PanicOnErr(hexutil.DecodeHex("0x997be92a22b1933f36e26fba5f721756f95811d6b4ae21564197c2bfa4f28270"))),
 				Address:              iotago.Ed25519AddressFromPubKey(lo.PanicOnErr(hexutil.DecodeHex("0x997be92a22b1933f36e26fba5f721756f95811d6b4ae21564197c2bfa4f28270"))),
-				Amount:               mock.MinIssuerAccountAmount(protocolParamsDocker),
+				Amount:               mock.MinIssuerAccountAmount(protoParams),
 				IssuerKey:            iotago.Ed25519PublicKeyHashBlockIssuerKeyFromPublicKey(ed25519.PublicKey(lo.PanicOnErr(hexutil.DecodeHex("0x997be92a22b1933f36e26fba5f721756f95811d6b4ae21564197c2bfa4f28270")))),
 				ExpirySlot:           iotago.MaxSlotIndex,
 				BlockIssuanceCredits: iotago.MaxBlockIssuanceCredits / 5,
-				Mana:                 iotago.Mana(mock.MinIssuerAccountAmount(protocolParamsDocker)),
+				Mana:                 iotago.Mana(mock.MinIssuerAccountAmount(protoParams)),
 			},
-		),
-		snapshotcreator.WithBasicOutputs(
-			/*
-				inx-faucet
-
-				Ed25519 Private Key:  de52b9964dda96564e9fab362ab16c2669c715c6a2a853bece8a25fc58c599755b938327ea463e0c323c0fd44f6fc1843ed94daecc6909c6043d06b7152e4737
-				Ed25519 Public Key:   5b938327ea463e0c323c0fd44f6fc1843ed94daecc6909c6043d06b7152e4737
-				Ed25519 Address:      rms1qqhkf7w30xv375z59vq7qd86qsa3j4qrsadcval04uvkkswg3qpaqf4hga2
-				Restricted Address:   rms1xqqz7e8e69uej86s2s4srcp5lgzrkx25qwr4hpnha7h3j66pezyq85qpqg55v3ur, Capabilities: mana
-			*/
-			snapshotcreator.BasicOutputDetails{
-				Address: lo.Return2(iotago.ParseBech32("rms1xqqz7e8e69uej86s2s4srcp5lgzrkx25qwr4hpnha7h3j66pezyq85qpqg55v3ur")),
-				Amount:  1_000_000_000_000_000,
-				Mana:    1_000_000_000_000_000,
-			},
-		),
+		}
 	}
 
-	// Feature is a preset for the feature network.
-	Feature = []options.Option[snapshotcreator.Options]{
-		snapshotcreator.WithFilePath("docker-network.snapshot"),
-		snapshotcreator.WithProtocolParameters(protocolParamsFeature),
-		snapshotcreator.WithAccounts(
-			snapshotcreator.AccountDetails{
+	AccountsFeatureFunc = func(protoParams iotago.ProtocolParameters) []snapshotcreator.AccountDetails {
+		return []snapshotcreator.AccountDetails{
+			{
 				/*
 					node-01-validator
 
@@ -180,16 +153,16 @@ var (
 				*/
 				AccountID:            blake2b.Sum256(lo.PanicOnErr(hexutil.DecodeHex("0x01fb6b9db5d96240aef00bc950d1c67a6494513f6d7cf784e57b4972b96ab2fe"))),
 				Address:              iotago.Ed25519AddressFromPubKey(lo.PanicOnErr(hexutil.DecodeHex("0x01fb6b9db5d96240aef00bc950d1c67a6494513f6d7cf784e57b4972b96ab2fe"))),
-				Amount:               mock.MinValidatorAccountAmount(protocolParamsFeature),
+				Amount:               mock.MinValidatorAccountAmount(protoParams),
 				IssuerKey:            iotago.Ed25519PublicKeyHashBlockIssuerKeyFromPublicKey(ed25519.PublicKey(lo.PanicOnErr(hexutil.DecodeHex("0x01fb6b9db5d96240aef00bc950d1c67a6494513f6d7cf784e57b4972b96ab2fe")))),
 				ExpirySlot:           iotago.MaxSlotIndex,
 				BlockIssuanceCredits: iotago.MaxBlockIssuanceCredits / 5,
 				StakingEndEpoch:      iotago.MaxEpochIndex,
 				FixedCost:            1,
-				StakedAmount:         mock.MinValidatorAccountAmount(protocolParamsFeature),
-				Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protocolParamsFeature)),
+				StakedAmount:         mock.MinValidatorAccountAmount(protoParams),
+				Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protoParams)),
 			},
-			snapshotcreator.AccountDetails{
+			{
 				/*
 					node-02-validator
 
@@ -200,16 +173,16 @@ var (
 				*/
 				AccountID:            blake2b.Sum256(lo.PanicOnErr(hexutil.DecodeHex("0x83e7f71a440afd48981a8b4684ddae24434b7182ce5c47cfb56ac528525fd4b6"))),
 				Address:              iotago.Ed25519AddressFromPubKey(lo.PanicOnErr(hexutil.DecodeHex("0x83e7f71a440afd48981a8b4684ddae24434b7182ce5c47cfb56ac528525fd4b6"))),
-				Amount:               mock.MinValidatorAccountAmount(protocolParamsFeature),
+				Amount:               mock.MinValidatorAccountAmount(protoParams),
 				IssuerKey:            iotago.Ed25519PublicKeyHashBlockIssuerKeyFromPublicKey(ed25519.PublicKey(lo.PanicOnErr(hexutil.DecodeHex("0x83e7f71a440afd48981a8b4684ddae24434b7182ce5c47cfb56ac528525fd4b6")))),
 				ExpirySlot:           iotago.MaxSlotIndex,
 				BlockIssuanceCredits: iotago.MaxBlockIssuanceCredits / 5,
 				StakingEndEpoch:      iotago.MaxEpochIndex,
 				FixedCost:            1,
-				StakedAmount:         mock.MinValidatorAccountAmount(protocolParamsFeature),
-				Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protocolParamsFeature)),
+				StakedAmount:         mock.MinValidatorAccountAmount(protoParams),
+				Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protoParams)),
 			},
-			snapshotcreator.AccountDetails{
+			{
 				/*
 					node-03-validator
 
@@ -220,16 +193,16 @@ var (
 				*/
 				AccountID:            blake2b.Sum256(lo.PanicOnErr(hexutil.DecodeHex("0xac628986b2ef52a1679f2289fcd7b4198476976dea4c30ae34ff04ae52e14805"))),
 				Address:              iotago.Ed25519AddressFromPubKey(lo.PanicOnErr(hexutil.DecodeHex("0xac628986b2ef52a1679f2289fcd7b4198476976dea4c30ae34ff04ae52e14805"))),
-				Amount:               mock.MinValidatorAccountAmount(protocolParamsFeature),
+				Amount:               mock.MinValidatorAccountAmount(protoParams),
 				IssuerKey:            iotago.Ed25519PublicKeyHashBlockIssuerKeyFromPublicKey(ed25519.PublicKey(lo.PanicOnErr(hexutil.DecodeHex("0xac628986b2ef52a1679f2289fcd7b4198476976dea4c30ae34ff04ae52e14805")))),
 				ExpirySlot:           iotago.MaxSlotIndex,
 				BlockIssuanceCredits: iotago.MaxBlockIssuanceCredits / 5,
 				StakingEndEpoch:      iotago.MaxEpochIndex,
 				FixedCost:            1,
-				StakedAmount:         mock.MinValidatorAccountAmount(protocolParamsFeature),
-				Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protocolParamsFeature)),
+				StakedAmount:         mock.MinValidatorAccountAmount(protoParams),
+				Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protoParams)),
 			},
-			snapshotcreator.AccountDetails{
+			{
 				/*
 					node-04-validator
 
@@ -241,16 +214,16 @@ var (
 				*/
 				AccountID:            blake2b.Sum256(lo.PanicOnErr(hexutil.DecodeHex("0xc9ceac37d293155a578381aa313ee74edfa3ac73ee930d045564aae7771e8ffe"))),
 				Address:              iotago.Ed25519AddressFromPubKey(lo.PanicOnErr(hexutil.DecodeHex("0xc9ceac37d293155a578381aa313ee74edfa3ac73ee930d045564aae7771e8ffe"))),
-				Amount:               mock.MinValidatorAccountAmount(protocolParamsFeature),
+				Amount:               mock.MinValidatorAccountAmount(protoParams),
 				IssuerKey:            iotago.Ed25519PublicKeyHashBlockIssuerKeyFromPublicKey(ed25519.PublicKey(lo.PanicOnErr(hexutil.DecodeHex("0xc9ceac37d293155a578381aa313ee74edfa3ac73ee930d045564aae7771e8ffe")))),
 				ExpirySlot:           iotago.MaxSlotIndex,
 				BlockIssuanceCredits: iotago.MaxBlockIssuanceCredits / 5,
 				StakingEndEpoch:      iotago.MaxEpochIndex,
 				FixedCost:            1,
-				StakedAmount:         mock.MinValidatorAccountAmount(protocolParamsFeature),
-				Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protocolParamsFeature)),
+				StakedAmount:         mock.MinValidatorAccountAmount(protoParams),
+				Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protoParams)),
 			},
-			snapshotcreator.AccountDetails{
+			{
 				/*
 					inx-blockissuer
 
@@ -261,26 +234,67 @@ var (
 				*/
 				AccountID:            blake2b.Sum256(lo.PanicOnErr(hexutil.DecodeHex("0x670a1a20ddb02a6cec53ec3196bc7d5bd26df2f5a6ca90b5fffd71364f104b25"))),
 				Address:              iotago.Ed25519AddressFromPubKey(lo.PanicOnErr(hexutil.DecodeHex("0x670a1a20ddb02a6cec53ec3196bc7d5bd26df2f5a6ca90b5fffd71364f104b25"))),
-				Amount:               mock.MinIssuerAccountAmount(protocolParamsFeature),
+				Amount:               mock.MinIssuerAccountAmount(protoParams),
 				IssuerKey:            iotago.Ed25519PublicKeyHashBlockIssuerKeyFromPublicKey(ed25519.PublicKey(lo.PanicOnErr(hexutil.DecodeHex("0x670a1a20ddb02a6cec53ec3196bc7d5bd26df2f5a6ca90b5fffd71364f104b25")))),
 				ExpirySlot:           iotago.MaxSlotIndex,
 				BlockIssuanceCredits: iotago.MaxBlockIssuanceCredits / 5,
-				Mana:                 iotago.Mana(mock.MinIssuerAccountAmount(protocolParamsFeature)),
+				Mana:                 iotago.Mana(mock.MinIssuerAccountAmount(protoParams)),
 			},
-		),
-		snapshotcreator.WithBasicOutputs(
-			/*
-				inx-faucet
+		}
+	}
 
-				Ed25519 Public Key:   dcd760a51cfafe901f4ca0745d399af7146028af643e8a339c7bb82fbb1be7f9
-				Ed25519 Address:      rms1qpy2e4my7cn9ydjx6hx0ytuq06tdxzm6kqry7dctvmagzxv9np0vg9c55n4
-				Restricted Address:   rms1xqqy3txhvnmzv53kgm2ueu30splfd5ct02cqvnehpdn04qgeskv9a3qpqgrhlhv3, Capabilities: mana
-			*/
-			snapshotcreator.BasicOutputDetails{
-				Address: lo.Return2(iotago.ParseBech32("rms1xqqy3txhvnmzv53kgm2ueu30splfd5ct02cqvnehpdn04qgeskv9a3qpqgrhlhv3")),
-				Amount:  1_000_000_000_000_000,
-				Mana:    1_000_000_000_000_000,
-			},
-		),
+	BasicOutputsDocker = []snapshotcreator.BasicOutputDetails{
+		/*
+			inx-faucet
+
+			Ed25519 Private Key:  de52b9964dda96564e9fab362ab16c2669c715c6a2a853bece8a25fc58c599755b938327ea463e0c323c0fd44f6fc1843ed94daecc6909c6043d06b7152e4737
+			Ed25519 Public Key:   5b938327ea463e0c323c0fd44f6fc1843ed94daecc6909c6043d06b7152e4737
+			Ed25519 Address:      rms1qqhkf7w30xv375z59vq7qd86qsa3j4qrsadcval04uvkkswg3qpaqf4hga2
+			Restricted Address:   rms1xqqz7e8e69uej86s2s4srcp5lgzrkx25qwr4hpnha7h3j66pezyq85qpqg55v3ur, Capabilities: mana
+		*/
+		{
+			Address: lo.Return2(iotago.ParseBech32("rms1xqqz7e8e69uej86s2s4srcp5lgzrkx25qwr4hpnha7h3j66pezyq85qpqg55v3ur")),
+			Amount:  1_000_000_000_000_000,
+			Mana:    1_000_000_000_000_000,
+		},
+	}
+
+	BasicOutputsFeature = []snapshotcreator.BasicOutputDetails{
+		/*
+			inx-faucet
+
+			Ed25519 Public Key:   dcd760a51cfafe901f4ca0745d399af7146028af643e8a339c7bb82fbb1be7f9
+			Ed25519 Address:      rms1qpy2e4my7cn9ydjx6hx0ytuq06tdxzm6kqry7dctvmagzxv9np0vg9c55n4
+			Restricted Address:   rms1xqqy3txhvnmzv53kgm2ueu30splfd5ct02cqvnehpdn04qgeskv9a3qpqgrhlhv3, Capabilities: mana
+		*/
+		{
+			Address: lo.Return2(iotago.ParseBech32("rms1xqqy3txhvnmzv53kgm2ueu30splfd5ct02cqvnehpdn04qgeskv9a3qpqgrhlhv3")),
+			Amount:  1_000_000_000_000_000,
+			Mana:    1_000_000_000_000_000,
+		},
+	}
+)
+
+var (
+	SnapshotOptionsBase = []options.Option[snapshotcreator.Options]{
+		snapshotcreator.WithDatabaseVersion(protocol.DatabaseVersion),
+		snapshotcreator.WithFilePath("snapshot.bin"),
+		snapshotcreator.WithProtocolParameters(ProtocolParamsBase),
+		snapshotcreator.WithAddGenesisRootBlock(true),
+	}
+
+	SnapshotOptionsDocker = []options.Option[snapshotcreator.Options]{
+		snapshotcreator.WithFilePath("docker-network.snapshot"),
+		snapshotcreator.WithProtocolParameters(ProtocolParamsDocker),
+		snapshotcreator.WithAccounts(AccountsDockerFunc(ProtocolParamsDocker)...),
+		snapshotcreator.WithBasicOutputs(BasicOutputsDocker...),
+	}
+
+	// SnapshotOptionsFeature is a preset for the feature network.
+	SnapshotOptionsFeature = []options.Option[snapshotcreator.Options]{
+		snapshotcreator.WithFilePath("docker-network.snapshot"),
+		snapshotcreator.WithProtocolParameters(ProtocolParamsFeature),
+		snapshotcreator.WithAccounts(AccountsFeatureFunc(ProtocolParamsFeature)...),
+		snapshotcreator.WithBasicOutputs(BasicOutputsFeature...),
 	}
 )

--- a/tools/genesis-snapshot/presets/presets_yaml.go
+++ b/tools/genesis-snapshot/presets/presets_yaml.go
@@ -53,14 +53,14 @@ func GenerateFromYaml(hostsFile string) ([]options.Option[snapshotcreator.Option
 		account := snapshotcreator.AccountDetails{
 			AccountID:            blake2b.Sum256(lo.PanicOnErr(hexutil.DecodeHex(pubkey))),
 			Address:              iotago.Ed25519AddressFromPubKey(lo.PanicOnErr(hexutil.DecodeHex(pubkey))),
-			Amount:               mock.MinValidatorAccountAmount(protocolParamsDocker),
+			Amount:               mock.MinValidatorAccountAmount(ProtocolParamsDocker),
 			IssuerKey:            iotago.Ed25519PublicKeyHashBlockIssuerKeyFromPublicKey(ed25519.PublicKey(lo.PanicOnErr(hexutil.DecodeHex(pubkey)))),
 			ExpirySlot:           iotago.MaxSlotIndex,
 			BlockIssuanceCredits: iotago.MaxBlockIssuanceCredits / 4,
 			StakingEndEpoch:      iotago.MaxEpochIndex,
 			FixedCost:            1,
-			StakedAmount:         mock.MinValidatorAccountAmount(protocolParamsDocker),
-			Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protocolParamsDocker)),
+			StakedAmount:         mock.MinValidatorAccountAmount(ProtocolParamsDocker),
+			Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(ProtocolParamsDocker)),
 		}
 		accounts = append(accounts, account)
 	}
@@ -71,11 +71,11 @@ func GenerateFromYaml(hostsFile string) ([]options.Option[snapshotcreator.Option
 		account := snapshotcreator.AccountDetails{
 			AccountID:            blake2b.Sum256(lo.PanicOnErr(hexutil.DecodeHex(pubkey))),
 			Address:              iotago.Ed25519AddressFromPubKey(lo.PanicOnErr(hexutil.DecodeHex(pubkey))),
-			Amount:               mock.MinValidatorAccountAmount(protocolParamsDocker),
+			Amount:               mock.MinValidatorAccountAmount(ProtocolParamsDocker),
 			IssuerKey:            iotago.Ed25519PublicKeyHashBlockIssuerKeyFromPublicKey(ed25519.PublicKey(lo.PanicOnErr(hexutil.DecodeHex(pubkey)))),
 			ExpirySlot:           iotago.MaxSlotIndex,
 			BlockIssuanceCredits: iotago.MaxBlockIssuanceCredits / 4,
-			Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(protocolParamsDocker)),
+			Mana:                 iotago.Mana(mock.MinValidatorAccountAmount(ProtocolParamsDocker)),
 		}
 		accounts = append(accounts, account)
 	}
@@ -95,7 +95,7 @@ func GenerateFromYaml(hostsFile string) ([]options.Option[snapshotcreator.Option
 
 	return []options.Option[snapshotcreator.Options]{
 		snapshotcreator.WithFilePath(configYaml.FilePath),
-		snapshotcreator.WithProtocolParameters(protocolParamsDocker),
+		snapshotcreator.WithProtocolParameters(ProtocolParamsDocker),
 		snapshotcreator.WithAccounts(accounts...),
 		snapshotcreator.WithBasicOutputs(basicOutputs...),
 	}, nil


### PR DESCRIPTION
I was hunting for the actual underlying bug in #753 and saw that there is a copy of the presets for the docker network in the docker network tests itself, which was not updated with the new increased values for the mana faucet.

To prevent this in the future from happening again, the code was refactored so that the presets can be reused in the docker-network test framework as well.