### PR TITLE
Extend mempool invalid signatures test

### DIFF
--- a/pkg/tests/mempool_invalid_signatures_test.go
+++ b/pkg/tests/mempool_invalid_signatures_test.go
@@ -10,7 +10,6 @@ import (
 
 // Test_MempoolInvalidSignatures attempts to recreate the bug in https://github.com/iotaledger/iota-core/issues/765
 func Test_MempoolInvalidSignatures(t *testing.T) {
-
 	ts := testsuite.NewTestSuite(t,
 		testsuite.WithProtocolParametersOptions(
 			iotago.WithTimeProviderOptions(
@@ -24,71 +23,46 @@ func Test_MempoolInvalidSignatures(t *testing.T) {
 	defer ts.Shutdown()
 
 	node1 := ts.AddValidatorNode("node1")
-	node2 := ts.AddValidatorNode("node2")
+	ts.AddValidatorNode("node2")
 	wallet := ts.AddDefaultWallet(node1)
 
 	ts.Run(true)
 
-	// split genesis output into 4 outputs for the further usage.
-	tx1 := wallet.CreateBasicOutputsEquallyFromInput("TX1", 4, "Genesis:0")
-	ts.IssueBasicBlockWithOptions("block0", wallet, tx1)
-
-	// Issue some more blocks to make transaction accepted
-	{
-		ts.IssueValidationBlockWithHeaderOptions("vblock0", node2, mock.WithStrongParents(ts.BlockID("block0")))
-		ts.IssueValidationBlockWithHeaderOptions("vblock1", node1, mock.WithStrongParents(ts.BlockID("vblock0")))
-		ts.IssueValidationBlockWithHeaderOptions("vblock2", node2, mock.WithStrongParents(ts.BlockID("vblock1")))
-
-		ts.AssertTransactionsInCacheAccepted(wallet.Transactions("TX1"), true, node1, node2)
-	}
-
-	transitionBasicOutputWithInvalidSignature(ts)
-}
-
-func transitionBasicOutputWithInvalidSignature(ts *testsuite.TestSuite) {
-	wallet := ts.DefaultWallet()
-
 	// Create a standard basic output transfer transaction.
-	tx3 := wallet.CreateBasicOutputsEquallyFromInput("TX3", 1, "TX1:0")
-	tx4 := tx3.Clone().(*iotago.SignedTransaction)
+	validTX := wallet.CreateBasicOutputsEquallyFromInput("TX", 1, "Genesis:0")
+	invalidTX := validTX.Clone().(*iotago.SignedTransaction)
 
 	// Make tx3 invalid by replacing the first unlock with an empty signature unlock.
-	_, is := tx3.Unlocks[0].(*iotago.SignatureUnlock)
+	_, is := invalidTX.Unlocks[0].(*iotago.SignatureUnlock)
 	if !is {
 		panic("expected signature unlock as first unlock")
 	}
-	tx3.Unlocks[0] = &iotago.SignatureUnlock{
+	invalidTX.Unlocks[0] = &iotago.SignatureUnlock{
 		Signature: &iotago.Ed25519Signature{},
 	}
 
 	// Issue the invalid attachment of the transaction.
-	ts.IssueBasicBlockWithOptions("block2", wallet, tx3)
+	ts.IssueBasicBlockWithOptions("block1", wallet, invalidTX)
 
-	ts.Wait(ts.Nodes()...)
-
-	// Ensure that the attachment is seen as invalid.
-	ts.AssertTransactionsExist([]*iotago.Transaction{tx3.Transaction}, true, ts.Nodes()...)
-	// TODO: This fails. The TX is still pending. Is this fine? The corresponding signed tx on the other hand is
-	// marked as failed/invalid as asserted below.
-	// ts.AssertTransactionsInCacheInvalid([]*iotago.Transaction{tx3.Transaction}, true, ts.Nodes()...)
-	signedTx3ID := tx3.MustID()
-	ts.AssertTransactionFailure(signedTx3ID, iotago.ErrDirectUnlockableAddressUnlockInvalid, ts.Nodes()...)
+	// Ensure that the attachment is seen as pending (tx) and failed (signed tx).
+	ts.AssertTransactionsExist([]*iotago.Transaction{invalidTX.Transaction}, true, ts.Nodes()...)
+	ts.AssertTransactionsInCacheAccepted([]*iotago.Transaction{invalidTX.Transaction}, false, ts.Nodes()...)
+	ts.AssertTransactionsInCachePending([]*iotago.Transaction{invalidTX.Transaction}, true, ts.Nodes()...)
+	ts.AssertTransactionFailure(invalidTX.MustID(), iotago.ErrDirectUnlockableAddressUnlockInvalid, ts.Nodes()...)
 
 	// Issue the valid attachment and another invalid attachment on top.
-	block3 := ts.IssueBasicBlockWithOptions("block3", wallet, tx4)
-	block4 := ts.IssueBasicBlockWithOptions("block4", wallet, tx3, mock.WithStrongParents(block3.ID()))
+	block2 := ts.IssueBasicBlockWithOptions("block2", wallet, validTX)
+	block3 := ts.IssueBasicBlockWithOptions("block3", wallet, invalidTX, mock.WithStrongParents(block2.ID()))
 
-	ts.CommitUntilSlot(block4.ID().Slot(), block4.ID())
+	// Accept block2 and block3.
+	ts.IssueBlocksAtSlots("accept-block3", []iotago.SlotIndex{block3.ID().Slot()}, 2, "block3", ts.Nodes(), false, true)
 
 	// Ensure that the valid attachment exists and got accepted,
 	// while the invalid attachment did not override the previous valid attachment.
-	ts.AssertTransactionsExist([]*iotago.Transaction{tx4.Transaction}, true, ts.Nodes()...)
-	ts.AssertTransactionsInCacheAccepted([]*iotago.Transaction{tx4.Transaction}, true, ts.Nodes()...)
+	ts.AssertTransactionsExist([]*iotago.Transaction{validTX.Transaction}, true, ts.Nodes()...)
+	ts.AssertTransactionsInCacheAccepted([]*iotago.Transaction{validTX.Transaction}, true, ts.Nodes()...)
 
-	// TODO: Fails with "block BlockID(block3:1) is root block". Do we even need to assert this?
-	// ts.AssertBlocksInCacheAccepted(ts.Blocks("block3"), true, ts.Nodes()...)
-	// ts.AssertBlocksInCacheInvalid(ts.Blocks("block3"), false, ts.Nodes()...)
-
-	// ts.AssertBlocksInCacheAccepted(ts.Blocks("block4"), false, ts.Nodes()...)
-	// ts.AssertBlocksInCacheInvalid(ts.Blocks("block4"), true, ts.Nodes()...)
+	// Both block should be accepted.
+	ts.AssertBlocksInCacheAccepted(ts.Blocks("block2"), true, ts.Nodes()...)
+	ts.AssertBlocksInCacheAccepted(ts.Blocks("block3"), true, ts.Nodes()...)
 }

--- a/pkg/testsuite/transactions.go
+++ b/pkg/testsuite/transactions.go
@@ -89,13 +89,13 @@ func (t *TestSuite) assertTransactionsInCacheWithFunc(expectedTransactions []*io
 			require.NoError(t.Testing, err)
 
 			t.Eventually(func() error {
-				blockFromCache, exists := node.Protocol.Engines.Main.Get().Ledger.TransactionMetadata(transactionID)
+				transactionFromCache, exists := node.Protocol.Engines.Main.Get().Ledger.TransactionMetadata(transactionID)
 				if !exists {
 					return ierrors.Errorf("assertTransactionsInCacheWithFunc: %s: transaction %s does not exist", node.Name, transactionID)
 				}
 
-				if expectedPropertyState != propertyFunc(blockFromCache) {
-					return ierrors.Errorf("assertTransactionsInCacheWithFunc: %s: transaction %s: expected %v, got %v", node.Name, blockFromCache.ID(), expectedPropertyState, propertyFunc(blockFromCache))
+				if expectedPropertyState != propertyFunc(transactionFromCache) {
+					return ierrors.Errorf("assertTransactionsInCacheWithFunc: %s: transaction %s: expected %v, got %v", node.Name, transactionFromCache.ID(), expectedPropertyState, propertyFunc(transactionFromCache))
 				}
 
 				return nil


### PR DESCRIPTION
Simplify & extend the mempool invalid signatures test. The implicit account creation was a leftover from an earlier test that also tested the problem fixed by iotaledger/iota.go#698, which is no longer necessary now. Hence the test can be simplified to use Basic Outputs.

Two outstanding TODOs in the comments that need to be resolved.

Fixes #794.
