### PR TITLE
Fix the expected return HTTP code in Test_CoreAPI_BadRequests

### DIFF
--- a/tools/docker-network/tests/coreapi_test.go
+++ b/tools/docker-network/tests/coreapi_test.go
@@ -572,7 +572,7 @@ func Test_CoreAPI_BadRequests(t *testing.T) {
 				txID := tpkg.RandTransactionID()
 				resp, err := d.wallet.Clients[nodeAlias].TransactionIncludedBlock(context.Background(), txID)
 				require.Error(t, err)
-				require.True(t, isStatusCode(err, http.StatusInternalServerError))
+				require.True(t, isStatusCode(err, http.StatusBadRequest))
 				require.Nil(t, resp)
 			},
 		},
@@ -583,7 +583,7 @@ func Test_CoreAPI_BadRequests(t *testing.T) {
 
 				resp, err := d.wallet.Clients[nodeAlias].TransactionIncludedBlockMetadata(context.Background(), txID)
 				require.Error(t, err)
-				require.True(t, isStatusCode(err, http.StatusInternalServerError))
+				require.True(t, isStatusCode(err, http.StatusBadRequest))
 				require.Nil(t, resp)
 			},
 		},


### PR DESCRIPTION
The randomly generated Transaction ID should fail at finding the included BlockID, thus BadRequest is returned.