### PR TITLE
Fix: Naming issue of commitments

### DIFF
--- a/pkg/core/promise/promise.go
+++ b/pkg/core/promise/promise.go
@@ -49,14 +49,16 @@ func New[T any](optResolver ...func(p *Promise[T])) *Promise[T] {
 	return p
 }
 
-// Resolve resolves the promise with the given result.
-func (p *Promise[T]) Resolve(result T) *Promise[T] {
+// ResolveDynamically resolves the promise with the result of the given resolve function.
+func (p *Promise[T]) ResolveDynamically(resolve func() T) *Promise[T] {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
 	if p.complete {
 		return p
 	}
+
+	result := resolve()
 
 	//nolint:revive
 	p.successCallbacks.ForEach(func(key types.UniqueID, callback func(T)) bool {
@@ -77,6 +79,13 @@ func (p *Promise[T]) Resolve(result T) *Promise[T] {
 	p.complete = true
 
 	return p
+}
+
+// Resolve resolves the promise with the given result.
+func (p *Promise[T]) Resolve(result T) *Promise[T] {
+	return p.ResolveDynamically(func() T {
+		return result
+	})
 }
 
 // Reject rejects the promise with the given error.

--- a/pkg/protocol/commitments.go
+++ b/pkg/protocol/commitments.go
@@ -214,14 +214,13 @@ func (c *Commitments) publishCommitment(commitment *model.Commitment) (published
 	}
 
 	// otherwise try to publish it and determine if we were the goroutine that published it
-	publishedCommitment = newCommitment(c, commitment)
-	cachedRequest.Resolve(publishedCommitment).OnSuccess(func(resolvedCommitment *Commitment) {
-		if published = resolvedCommitment == publishedCommitment; !published {
-			publishedCommitment = resolvedCommitment
-		}
+	cachedRequest.ResolveDynamically(func() *Commitment {
+		published = true
+
+		return newCommitment(c, commitment)
 	})
 
-	return publishedCommitment, published, nil
+	return cachedRequest.Result(), published, nil
 }
 
 // cachedRequest returns a singleton Promise for the given commitmentID. If the Promise does not exist yet, it will be


### PR DESCRIPTION
This PR fixes a naming issue for the logger of commitments, that caused the commitments to increase their human readable name counter even if the corresponding commitment never gets published.