### PR TITLE
Fix chain engine traversal

### DIFF
--- a/pkg/protocol/chain.go
+++ b/pkg/protocol/chain.go
@@ -179,10 +179,9 @@ func (c *Chain) CumulativeVerifiedWeightAt(slot iotago.SlotIndex) uint64 {
 func (c *Chain) LatestEngine() *engine.Engine {
 	currentChain, currentEngine := c, c.Engine.Get()
 
+	// traverse the chain upwards until we find an engine
 	for currentEngine == nil {
-		// traverse the chain upwards until we find an engine
-		currentChain = currentChain.ParentChain.Get()
-		if currentChain == nil {
+		if currentChain = currentChain.ParentChain.Get(); currentChain == nil {
 			// no parent chain and therefore no engine found
 			return nil
 		}

--- a/pkg/protocol/chain.go
+++ b/pkg/protocol/chain.go
@@ -178,10 +178,16 @@ func (c *Chain) CumulativeVerifiedWeightAt(slot iotago.SlotIndex) uint64 {
 // LatestEngine returns the latest engine instance that was spawned by the chain itself or one of its ancestors.
 func (c *Chain) LatestEngine() *engine.Engine {
 	currentChain, currentEngine := c, c.Engine.Get()
-	for ; currentEngine == nil; currentEngine = currentChain.Engine.Get() {
-		if currentChain = currentChain.ParentChain.Get(); currentChain == nil {
+
+	for currentEngine == nil {
+		// traverse the chain upwards until we find an engine
+		currentChain = currentChain.ParentChain.Get()
+		if currentChain == nil {
+			// no parent chain and therefore no engine found
 			return nil
 		}
+
+		currentEngine = currentChain.Engine.Get()
 	}
 
 	return currentEngine

--- a/pkg/protocol/chain.go
+++ b/pkg/protocol/chain.go
@@ -179,7 +179,7 @@ func (c *Chain) CumulativeVerifiedWeightAt(slot iotago.SlotIndex) uint64 {
 func (c *Chain) LatestEngine() *engine.Engine {
 	currentChain, currentEngine := c, c.Engine.Get()
 	for ; currentEngine == nil; currentEngine = currentChain.Engine.Get() {
-		if currentChain = c.ParentChain.Get(); currentChain == nil {
+		if currentChain = currentChain.ParentChain.Get(); currentChain == nil {
 			return nil
 		}
 	}


### PR DESCRIPTION
This PR solves two bugs.

First there could have been an infinite loop because we used the wrong variable to traverse the parent chains. See first commit.

Second there could have been an edge case where an engine was found in the loop header because the assignment is executed after the loop condition, but the check for the parent chain inside the loop was nil, which caused the function to return nil instead of the newly found engine, which ultimately resulted in a nil pointer exception.

Should fix #842 