### PR TITLE
Avoid re-encoding blocks to calculate the ID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/iotaledger/hive.go/stringify v0.0.0-20240320122938-13a946cf3c7a
 	github.com/iotaledger/inx-app v1.0.0-rc.3.0.20240307101848-db58eb9353ec
 	github.com/iotaledger/inx/go v1.0.0-rc.2.0.20240307100839-48553e1d2022
-	github.com/iotaledger/iota.go/v4 v4.0.0-20240321174445-4e586367e5bd
+	github.com/iotaledger/iota.go/v4 v4.0.0-20240322111205-845f859ca28c
 	github.com/labstack/echo/v4 v4.11.4
 	github.com/labstack/gommon v0.4.2
 	github.com/libp2p/go-libp2p v0.33.1

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/iotaledger/inx/go v1.0.0-rc.2.0.20240307100839-48553e1d2022 h1:I178Sa
 github.com/iotaledger/inx/go v1.0.0-rc.2.0.20240307100839-48553e1d2022/go.mod h1:jTFxIWiMUdAwO263jlJCSWcNLqEkgYEVOFXfjp5aNJM=
 github.com/iotaledger/iota-crypto-demo v0.0.0-20240320124000-d02f37a4fdff h1:Do8fakxvFaj7dLckoo/z+mRyBdZo8QvT8HcgnQlG2Sg=
 github.com/iotaledger/iota-crypto-demo v0.0.0-20240320124000-d02f37a4fdff/go.mod h1:aVEutEWFnhDNJBxtVuzy2BeTN+8FAlnR83k7hKV0CFE=
-github.com/iotaledger/iota.go/v4 v4.0.0-20240321174445-4e586367e5bd h1:GD6XJA52pPknOsMTBNXC/6VB/vtxrKVW2CDdeLRt0eQ=
-github.com/iotaledger/iota.go/v4 v4.0.0-20240321174445-4e586367e5bd/go.mod h1:qn/63CB0/jE1em6ewqDSiz+ovS+E/os7K5b7g2pmJFg=
+github.com/iotaledger/iota.go/v4 v4.0.0-20240322111205-845f859ca28c h1:xnaAczQXgcm4FL/z6q/r5WqUsyxqsUcs/hEdikQjjQ0=
+github.com/iotaledger/iota.go/v4 v4.0.0-20240322111205-845f859ca28c/go.mod h1:qn/63CB0/jE1em6ewqDSiz+ovS+E/os7K5b7g2pmJFg=
 github.com/ipfs/boxo v0.18.0 h1:MOL9/AgoV3e7jlVMInicaSdbgralfqSsbkc31dZ9tmw=
 github.com/ipfs/boxo v0.18.0/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/ipfs/go-cid v0.4.1 h1:A/T3qGvxi4kpKWWcPC/PgbvDA2bjVLO7n4UeVwnbs/s=

--- a/pkg/network/protocols/core/protocol.go
+++ b/pkg/network/protocols/core/protocol.go
@@ -205,7 +205,7 @@ func (p *Protocol) onBlock(blockData []byte, id peer.ID) {
 		return
 	}
 
-	block, err := model.BlockFromBytes(blockData, p.apiProvider)
+	block, err := model.BlockFromBlockIdentifierAndBytes(blockIdentifier, blockData, p.apiProvider)
 	if err != nil {
 		p.Events.Error.Trigger(ierrors.Wrap(err, "failed to deserialize block"), id)
 		return

--- a/pkg/protocol/engine/booker/inmemorybooker/booker.go
+++ b/pkg/protocol/engine/booker/inmemorybooker/booker.go
@@ -225,7 +225,7 @@ func (b *Booker) inheritSpenders(block *blocks.Block) (spenderIDs ds.Set[iotago.
 
 			// Check whether the parent contains a conflicting TX,
 			// otherwise reference is invalid and the block should be marked as invalid as well.
-			if signedTransaction, hasTx := parentBlock.SignedTransaction(); !hasTx || !parentBlock.PayloadSpenderIDs().Has(signedTransaction.Transaction.MustID()) {
+			if _, hasTx := parentBlock.SignedTransaction(); !hasTx {
 				return nil, ierrors.Wrapf(err, "shallow like parent %s does not contain a conflicting transaction", parent.ID.String())
 			}
 

--- a/pkg/protocol/engine/filter/presolidfilter/presolidblockfilter/pre_solid_block_filter.go
+++ b/pkg/protocol/engine/filter/presolidfilter/presolidblockfilter/pre_solid_block_filter.go
@@ -82,7 +82,7 @@ func (f *PreSolidBlockFilter) ProcessReceivedBlock(block *model.Block, source pe
 	}
 
 	if _, isValidation := block.ValidationBlock(); isValidation {
-		blockSlot := block.ProtocolBlock().API.TimeProvider().SlotFromTime(block.ProtocolBlock().Header.IssuingTime)
+		blockSlot := block.ProtocolBlock().Slot()
 		committee, exists := f.committeeFunc(blockSlot)
 		if !exists {
 			f.events.BlockPreFiltered.Trigger(&presolidfilter.BlockPreFilteredEvent{

--- a/tools/gendoc/go.mod
+++ b/tools/gendoc/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/iotaledger/inx-app v1.0.0-rc.3.0.20240307101848-db58eb9353ec // indirect
 	github.com/iotaledger/inx/go v1.0.0-rc.2.0.20240307100839-48553e1d2022 // indirect
 	github.com/iotaledger/iota-crypto-demo v0.0.0-20240320124000-d02f37a4fdff // indirect
-	github.com/iotaledger/iota.go/v4 v4.0.0-20240321174445-4e586367e5bd // indirect
+	github.com/iotaledger/iota.go/v4 v4.0.0-20240322111205-845f859ca28c // indirect
 	github.com/ipfs/boxo v0.18.0 // indirect
 	github.com/ipfs/go-cid v0.4.1 // indirect
 	github.com/ipfs/go-datastore v0.6.0 // indirect

--- a/tools/gendoc/go.sum
+++ b/tools/gendoc/go.sum
@@ -331,6 +331,7 @@ github.com/iotaledger/iota-crypto-demo v0.0.0-20240320124000-d02f37a4fdff h1:Do8
 github.com/iotaledger/iota-crypto-demo v0.0.0-20240320124000-d02f37a4fdff/go.mod h1:aVEutEWFnhDNJBxtVuzy2BeTN+8FAlnR83k7hKV0CFE=
 github.com/iotaledger/iota.go/v4 v4.0.0-20240321174445-4e586367e5bd h1:GD6XJA52pPknOsMTBNXC/6VB/vtxrKVW2CDdeLRt0eQ=
 github.com/iotaledger/iota.go/v4 v4.0.0-20240321174445-4e586367e5bd/go.mod h1:qn/63CB0/jE1em6ewqDSiz+ovS+E/os7K5b7g2pmJFg=
+github.com/iotaledger/iota.go/v4 v4.0.0-20240322111205-845f859ca28c/go.mod h1:qn/63CB0/jE1em6ewqDSiz+ovS+E/os7K5b7g2pmJFg=
 github.com/ipfs/boxo v0.18.0 h1:MOL9/AgoV3e7jlVMInicaSdbgralfqSsbkc31dZ9tmw=
 github.com/ipfs/boxo v0.18.0/go.mod h1:pIZgTWdm3k3pLF9Uq6MB8JEcW07UDwNJjlXW1HELW80=
 github.com/ipfs/go-cid v0.4.1 h1:A/T3qGvxi4kpKWWcPC/PgbvDA2bjVLO7n4UeVwnbs/s=


### PR DESCRIPTION
- Avoid re-encoding and re-hashing the blocks when received over the network
- Remove check if a block has its own tx as a payload spender since we always fork on conflicts. This avoid re-encoding the transaction to calculate the ID