### PR TITLE
Return accepted/confirmed in ListenToAcceptedBlocks and ListenToConfirmedBlocks

### DIFF
--- a/components/inx/server_blocks.go
+++ b/components/inx/server_blocks.go
@@ -14,6 +14,7 @@ import (
 	"github.com/iotaledger/iota-core/pkg/model"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/blocks"
 	iotago "github.com/iotaledger/iota.go/v4"
+	"github.com/iotaledger/iota.go/v4/api"
 )
 
 func (s *Server) ReadActiveRootBlocks(_ context.Context, _ *inx.NoParams) (*inx.RootBlocksResponse, error) {
@@ -78,7 +79,10 @@ func (s *Server) ListenToAcceptedBlocks(_ *inx.NoParams, srv inx.INX_ListenToAcc
 	wp := workerpool.New("ListenToAcceptedBlocks", workerpool.WithWorkerCount(workerCount)).Start()
 
 	unhook := deps.Protocol.Events.Engine.BlockGadget.BlockAccepted.Hook(func(block *blocks.Block) {
-		payload, err := getINXBlockMetadata(block.ID())
+		payload, err := inx.WrapBlockMetadata(&api.BlockMetadataResponse{
+			BlockID:    block.ID(),
+			BlockState: api.BlockStateAccepted,
+		})
 		if err != nil {
 			Component.LogErrorf("get block metadata error: %v", err)
 			cancel()
@@ -115,7 +119,10 @@ func (s *Server) ListenToConfirmedBlocks(_ *inx.NoParams, srv inx.INX_ListenToCo
 	wp := workerpool.New("ListenToConfirmedBlocks", workerpool.WithWorkerCount(workerCount)).Start()
 
 	unhook := deps.Protocol.Events.Engine.BlockGadget.BlockConfirmed.Hook(func(block *blocks.Block) {
-		payload, err := getINXBlockMetadata(block.ID())
+		payload, err := inx.WrapBlockMetadata(&api.BlockMetadataResponse{
+			BlockID:    block.ID(),
+			BlockState: api.BlockStateConfirmed,
+		})
 		if err != nil {
 			Component.LogErrorf("get block metadata error: %v", err)
 			cancel()

--- a/tools/docker-network/tests/eventapiframework.go
+++ b/tools/docker-network/tests/eventapiframework.go
@@ -85,6 +85,8 @@ func (e *EventAPIDockerTestFramework) AssertBlockMetadataStateAcceptedBlocks(ctx
 		for {
 			select {
 			case blk := <-acceptedChan:
+				require.Equal(e.Testing, api.BlockStateAccepted, blk.BlockState, "Block %s is pending in BlockMetadataAccepted topic", blk.BlockID.ToHex())
+
 				resp, err := eventClt.Client.BlockMetadataByBlockID(ctx, blk.BlockID)
 				require.NoError(e.Testing, err)
 				// accepted, confirmed are accepted
@@ -110,6 +112,8 @@ func (e *EventAPIDockerTestFramework) AssertBlockMetadataStateConfirmedBlocks(ct
 		for {
 			select {
 			case blk := <-acceptedChan:
+				require.Equal(e.Testing, api.BlockStateConfirmed, blk.BlockState, "Block %s is pending in BlockMetadataConfirmed topic", blk.BlockID.ToHex())
+
 				resp, err := eventClt.Client.BlockMetadataByBlockID(ctx, blk.BlockID)
 				require.NoError(e.Testing, err)
 				require.NotEqualf(e.Testing, api.BlockStatePending, resp.BlockState, "Block %s is pending in BlockMetadataConfirmed endpoint", blk.BlockID.ToHex())


### PR DESCRIPTION
BlockState is retained via workpool, so the state might not be updated to accepted/confirmed by the time that inx retrieves it from BlockRetainer, since both are triggered by BlockAccepted/BlockConfirmed event, we can safely return the state directly instead of fetching it again from the BlockRetainer.

A fix to #779 