### PR TITLE
Remove execution workerpool 

### DIFF
--- a/pkg/protocol/engine/booker/inmemorybooker/booker.go
+++ b/pkg/protocol/engine/booker/inmemorybooker/booker.go
@@ -107,8 +107,8 @@ func (b *Booker) Queue(block *blocks.Block) error {
 
 	// Based on the assumption that we always fork and the UTXO and Tangle past cones are always fully known.
 	signedTransactionMetadata.OnSignaturesValid(func() {
-		b.LogTrace("signatures valid", "blockID", block.ID())
 		transactionMetadata := signedTransactionMetadata.TransactionMetadata()
+		b.LogTrace("signatures valid", "blockID", block.ID(), "transactionID", transactionMetadata.ID())
 
 		if orphanedSlot, isOrphaned := transactionMetadata.OrphanedSlot(); isOrphaned && orphanedSlot <= block.SlotCommitmentID().Slot() {
 			block.SetInvalid()

--- a/pkg/protocol/engine/booker/inmemorybooker/booker.go
+++ b/pkg/protocol/engine/booker/inmemorybooker/booker.go
@@ -93,8 +93,9 @@ func (b *Booker) Init(ledger ledger.Ledger, loadBlockFromStorage func(iotago.Blo
 
 // Queue checks if payload is solid and then sets up the block to react to its parents.
 func (b *Booker) Queue(block *blocks.Block) error {
+	b.LogTrace("attaching transaction...", "blockID", block.ID())
 	signedTransactionMetadata, containsTransaction := b.ledger.AttachTransaction(block)
-
+	b.LogTrace("transaction attached, waiting for signature check", "blockID", block.ID())
 	if !containsTransaction {
 		b.setupBlock(block)
 		return nil
@@ -106,6 +107,7 @@ func (b *Booker) Queue(block *blocks.Block) error {
 
 	// Based on the assumption that we always fork and the UTXO and Tangle past cones are always fully known.
 	signedTransactionMetadata.OnSignaturesValid(func() {
+		b.LogTrace("signatures valid", "blockID", block.ID())
 		transactionMetadata := signedTransactionMetadata.TransactionMetadata()
 
 		if orphanedSlot, isOrphaned := transactionMetadata.OrphanedSlot(); isOrphaned && orphanedSlot <= block.SlotCommitmentID().Slot() {
@@ -115,6 +117,8 @@ func (b *Booker) Queue(block *blocks.Block) error {
 		}
 
 		transactionMetadata.OnBooked(func() {
+			b.LogTrace("transactionMetadata booked, setup block", "blockID", block.ID())
+
 			block.SetPayloadSpenderIDs(transactionMetadata.SpenderIDs())
 			b.setupBlock(block)
 		})
@@ -148,6 +152,7 @@ func (b *Booker) setupBlock(block *blocks.Block) {
 
 		parentBlock.Booked().OnUpdateOnce(func(_ bool, _ bool) {
 			if unbookedParentsCount.Add(-1) == 0 {
+				b.LogTrace("start booking ", "blockID", block.ID())
 				if err := b.book(block); err != nil {
 					if block.SetInvalid() {
 						b.events.BlockInvalid.Trigger(block, ierrors.Wrap(err, "failed to book block"))

--- a/pkg/protocol/engine/ledger/ledger/ledger.go
+++ b/pkg/protocol/engine/ledger/ledger/ledger.go
@@ -69,7 +69,7 @@ func NewProvider() module.Provider[*engine.Engine, ledger.Ledger] {
 			})
 			e.Events.SpendDAG.LinkTo(l.spendDAG.Events())
 
-			l.memPool = mempoolv1.New(NewVM(l), l.resolveState, e.Storage.Mutations, e.Workers.CreateGroup("MemPool"), l.spendDAG, l.apiProvider, l.errorHandler)
+			l.memPool = mempoolv1.New(NewVM(l), l.resolveState, e.Storage.Mutations, l.spendDAG, l.apiProvider, l.errorHandler)
 
 			l.manaManager = mana.NewManager(l.apiProvider, l.resolveAccountOutput, l.accountsLedger.Account)
 			latestCommittedSlot := e.Storage.Settings().LatestCommitment().Slot()

--- a/pkg/protocol/engine/mempool/tests/testframework.go
+++ b/pkg/protocol/engine/mempool/tests/testframework.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/iotaledger/hive.go/lo"
 	"github.com/iotaledger/hive.go/runtime/debug"
-	"github.com/iotaledger/hive.go/runtime/workerpool"
 	"github.com/iotaledger/iota-core/pkg/core/vote"
 	ledgertests "github.com/iotaledger/iota-core/pkg/protocol/engine/ledger/tests"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/mempool"
@@ -28,12 +27,11 @@ type TestFramework struct {
 	blockIDsByAlias          map[string]iotago.BlockID
 
 	ledgerState *ledgertests.MockStateResolver
-	workers     *workerpool.Group
 
 	test *testing.T
 }
 
-func NewTestFramework(t *testing.T, instance mempool.MemPool[vote.MockedRank], spendDAG spenddag.SpendDAG[iotago.TransactionID, mempool.StateID, vote.MockedRank], ledgerState *ledgertests.MockStateResolver, workers *workerpool.Group) *TestFramework {
+func NewTestFramework(t *testing.T, instance mempool.MemPool[vote.MockedRank], spendDAG spenddag.SpendDAG[iotago.TransactionID, mempool.StateID, vote.MockedRank], ledgerState *ledgertests.MockStateResolver) *TestFramework {
 	t.Helper()
 
 	tf := &TestFramework{
@@ -46,7 +44,6 @@ func NewTestFramework(t *testing.T, instance mempool.MemPool[vote.MockedRank], s
 		blockIDsByAlias:          make(map[string]iotago.BlockID),
 
 		ledgerState: ledgerState,
-		workers:     workers,
 		test:        t,
 	}
 
@@ -379,12 +376,7 @@ func (t *TestFramework) AssertStateDiff(slot iotago.SlotIndex, spentOutputAliase
 	}
 }
 
-func (t *TestFramework) WaitChildren() {
-	t.workers.WaitChildren()
-}
-
 func (t *TestFramework) Cleanup() {
-	t.workers.WaitChildren()
 	t.ledgerState.Cleanup()
 
 	iotago.UnregisterIdentifierAliases()

--- a/pkg/protocol/engine/mempool/v1/mempool.go
+++ b/pkg/protocol/engine/mempool/v1/mempool.go
@@ -418,17 +418,17 @@ func (m *MemPool[VoteRank]) solidifyInputs(transaction *TransactionMetadata) {
 func (m *MemPool[VoteRank]) executeTransaction(executionContext context.Context, transaction *TransactionMetadata) {
 	start3 := time.Now()
 
-	m.executionWorkers.Submit(func() {
-		if outputStates, err := m.vm.Execute(executionContext, transaction.Transaction()); err != nil {
-			transaction.setInvalid(err)
-		} else {
-			fmt.Println(">> execution took", time.Since(start3), " - ", transaction.ID())
+	//m.executionWorkers.Submit(func() {
+	if outputStates, err := m.vm.Execute(executionContext, transaction.Transaction()); err != nil {
+		transaction.setInvalid(err)
+	} else {
+		fmt.Println(">> execution took", time.Since(start3), " - ", transaction.ID())
 
-			transaction.setExecuted(outputStates)
+		transaction.setExecuted(outputStates)
 
-			m.bookTransaction(transaction)
-		}
-	})
+		m.bookTransaction(transaction)
+	}
+	//})
 }
 
 func (m *MemPool[VoteRank]) bookTransaction(transaction *TransactionMetadata) {

--- a/pkg/protocol/engine/mempool/v1/mempool.go
+++ b/pkg/protocol/engine/mempool/v1/mempool.go
@@ -12,7 +12,6 @@ import (
 	"github.com/iotaledger/hive.go/runtime/event"
 	"github.com/iotaledger/hive.go/runtime/options"
 	"github.com/iotaledger/hive.go/runtime/syncutils"
-	"github.com/iotaledger/hive.go/runtime/workerpool"
 	"github.com/iotaledger/iota-core/pkg/core/promise"
 	"github.com/iotaledger/iota-core/pkg/core/vote"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/mempool"
@@ -78,7 +77,6 @@ func New[VoteRank spenddag.VoteRankType[VoteRank]](
 	vm mempool.VM,
 	stateResolver mempool.StateResolver,
 	mutationsFunc func(iotago.SlotIndex) (kvstore.KVStore, error),
-	workers *workerpool.Group,
 	spendDAG spenddag.SpendDAG[iotago.TransactionID, mempool.StateID, VoteRank],
 	apiProvider iotago.APIProvider,
 	errorHandler func(error),

--- a/pkg/protocol/engine/mempool/v1/mempool.go
+++ b/pkg/protocol/engine/mempool/v1/mempool.go
@@ -416,9 +416,9 @@ func (m *MemPool[VoteRank]) solidifyInputs(transaction *TransactionMetadata) {
 }
 
 func (m *MemPool[VoteRank]) executeTransaction(executionContext context.Context, transaction *TransactionMetadata) {
-	m.executionWorkers.Submit(func() {
-		start3 := time.Now()
+	start3 := time.Now()
 
+	m.executionWorkers.Submit(func() {
 		if outputStates, err := m.vm.Execute(executionContext, transaction.Transaction()); err != nil {
 			transaction.setInvalid(err)
 		} else {

--- a/pkg/protocol/engine/mempool/v1/mempool.go
+++ b/pkg/protocol/engine/mempool/v1/mempool.go
@@ -98,7 +98,7 @@ func New[VoteRank spenddag.VoteRankType[VoteRank]](
 		cachedSignedTransactions:   shrinkingmap.New[iotago.SignedTransactionID, *SignedTransactionMetadata](),
 		cachedStateRequests:        shrinkingmap.New[mempool.StateID, *promise.Promise[*StateMetadata]](),
 		stateDiffs:                 shrinkingmap.New[iotago.SlotIndex, *StateDiff](),
-		executionWorkers:           workers.CreatePool("executionWorkers", workerpool.WithWorkerCount(1)),
+		executionWorkers:           workers.CreatePool("executionWorkers", workerpool.WithWorkerCount(6)),
 		delayedTransactionEviction: shrinkingmap.New[iotago.SlotIndex, ds.Set[iotago.TransactionID]](),
 		delayedOutputStateEviction: shrinkingmap.New[iotago.SlotIndex, *shrinkingmap.ShrinkingMap[iotago.Identifier, *StateMetadata]](),
 		spendDAG:                   spendDAG,


### PR DESCRIPTION
Execution workerpool with 1 worker was a bottleneck. It works much faster with VM execution by the same goroutine that is processing the block. 