### PR TITLE
Fix witness and ratifier reading 

### DIFF
--- a/components/debugapi/debug_models.go
+++ b/components/debugapi/debug_models.go
@@ -81,7 +81,7 @@ func BlockMetadataResponseFromBlock(block *blocks.Block) *BlockMetadataResponse 
 		Accepted:           block.IsAccepted(),
 		PreConfirmed:       block.IsPreConfirmed(),
 		Confirmed:          block.IsConfirmed(),
-		Witnesses:          lo.Map(block.Witnesses(), func(seatIndex account.SeatIndex) string { return fmt.Sprintf("%d", seatIndex) }),
+		Witnesses:          lo.Map(block.Witnesses().ToSlice(), func(seatIndex account.SeatIndex) string { return fmt.Sprintf("%d", seatIndex) }),
 		SpenderIDs:         block.SpenderIDs().ToSlice(),
 		PayloadSpenderIDs:  block.PayloadSpenderIDs().ToSlice(),
 		String:             block.String(),

--- a/pkg/protocol/engine/blocks/block.go
+++ b/pkg/protocol/engine/blocks/block.go
@@ -367,11 +367,11 @@ func (b *Block) WitnessCount() int {
 	return b.witnesses.Size()
 }
 
-func (b *Block) Witnesses() []account.SeatIndex {
+func (b *Block) Witnesses() ds.ReadableSet[account.SeatIndex] {
 	b.mutex.RLock()
 	defer b.mutex.RUnlock()
 
-	return b.witnesses.ToSlice()
+	return b.witnesses
 }
 
 func (b *Block) SpenderIDs() ds.Set[iotago.TransactionID] {
@@ -424,11 +424,11 @@ func (b *Block) AddAcceptanceRatifier(seat account.SeatIndex) (added bool) {
 	return b.acceptanceRatifiers.Add(seat)
 }
 
-func (b *Block) AcceptanceRatifiers() []account.SeatIndex {
+func (b *Block) AcceptanceRatifiers() ds.ReadableSet[account.SeatIndex] {
 	b.mutex.RLock()
 	defer b.mutex.RUnlock()
 
-	return b.acceptanceRatifiers.ToSlice()
+	return b.acceptanceRatifiers
 }
 
 // Accepted returns a reactive variable that is true if the Block was accepted.
@@ -536,11 +536,11 @@ func (b *Block) AddConfirmationRatifier(seat account.SeatIndex) (added bool) {
 	return b.confirmationRatifiers.Add(seat)
 }
 
-func (b *Block) ConfirmationRatifiers() []account.SeatIndex {
+func (b *Block) ConfirmationRatifiers() ds.ReadableSet[account.SeatIndex] {
 	b.mutex.RLock()
 	defer b.mutex.RUnlock()
 
-	return b.confirmationRatifiers.ToSlice()
+	return b.confirmationRatifiers
 }
 
 func (b *Block) IsConfirmed() bool {

--- a/pkg/protocol/engine/consensus/blockgadget/thresholdblockgadget/acceptance_ratification.go
+++ b/pkg/protocol/engine/consensus/blockgadget/thresholdblockgadget/acceptance_ratification.go
@@ -53,7 +53,7 @@ func (g *Gadget) trackAcceptanceRatifierWeight(votingBlock *blocks.Block) {
 }
 
 func (g *Gadget) shouldAccept(block *blocks.Block) bool {
-	blockSeats := len(block.AcceptanceRatifiers())
+	blockSeats := block.AcceptanceRatifiers().Size()
 	onlineCommitteeTotalSeats := g.seatManager.OnlineCommittee().Size()
 
 	return votes.IsThresholdReached(blockSeats, onlineCommitteeTotalSeats, g.optsAcceptanceThreshold)

--- a/pkg/protocol/engine/consensus/blockgadget/thresholdblockgadget/confirmation_ratification.go
+++ b/pkg/protocol/engine/consensus/blockgadget/thresholdblockgadget/confirmation_ratification.go
@@ -59,7 +59,7 @@ func (g *Gadget) trackConfirmationRatifierWeight(votingBlock *blocks.Block) {
 }
 
 func (g *Gadget) shouldConfirm(block *blocks.Block) bool {
-	blockSeats := len(block.ConfirmationRatifiers())
+	blockSeats := block.ConfirmationRatifiers().Size()
 	totalCommitteeSeats := g.seatManager.SeatCountInSlot(block.ID().Slot())
 
 	return votes.IsThresholdReached(blockSeats, totalCommitteeSeats, g.optsConfirmationThreshold)

--- a/pkg/protocol/engine/consensus/blockgadget/thresholdblockgadget/gadget.go
+++ b/pkg/protocol/engine/consensus/blockgadget/thresholdblockgadget/gadget.go
@@ -1,8 +1,6 @@
 package thresholdblockgadget
 
 import (
-	"fmt"
-
 	"github.com/iotaledger/hive.go/ds"
 	"github.com/iotaledger/hive.go/ds/walker"
 	"github.com/iotaledger/hive.go/ierrors"

--- a/pkg/protocol/engine/consensus/blockgadget/thresholdblockgadget/gadget.go
+++ b/pkg/protocol/engine/consensus/blockgadget/thresholdblockgadget/gadget.go
@@ -80,10 +80,6 @@ func (g *Gadget) propagate(initialBlockIDs iotago.BlockIDs, evaluateFunc func(bl
 			continue
 		}
 
-		if !block.IsBooked() {
-			panic(fmt.Sprintf("block %s is not booked", blockID))
-		}
-
 		if !evaluateFunc(block) {
 			continue
 		}

--- a/pkg/protocol/engine/consensus/blockgadget/thresholdblockgadget/witness_weight.go
+++ b/pkg/protocol/engine/consensus/blockgadget/thresholdblockgadget/witness_weight.go
@@ -96,14 +96,13 @@ func (g *Gadget) TrackWitnessWeight(votingBlock *blocks.Block) {
 
 func (g *Gadget) shouldPreAcceptAndPreConfirm(block *blocks.Block) (preAccept bool, preConfirm bool) {
 	committeeTotalSeats := g.seatManager.SeatCountInSlot(block.ID().Slot())
-	blockSeats := len(block.Witnesses())
+	blockSeats := block.Witnesses().Size()
 
 	onlineCommitteeTotalSeats := g.seatManager.OnlineCommittee().Size()
-	blockSeatsOnline := len(block.Witnesses())
 
 	if votes.IsThresholdReached(blockSeats, committeeTotalSeats, g.optsConfirmationThreshold) {
 		return true, true
-	} else if votes.IsThresholdReached(blockSeatsOnline, onlineCommitteeTotalSeats, g.optsAcceptanceThreshold) {
+	} else if votes.IsThresholdReached(blockSeats, onlineCommitteeTotalSeats, g.optsAcceptanceThreshold) {
 		return true, false
 	}
 


### PR DESCRIPTION
This PR exposes `blocks.Witnesses()` and `blocks.Ratifiers` as readable sets to avoid copying and subsequent contention when adding a voter to witnesses/ratifiers.