### PR TITLE
BIC underflow

### DIFF
--- a/pkg/protocol/engine/accounts/accountsledger/manager.go
+++ b/pkg/protocol/engine/accounts/accountsledger/manager.go
@@ -531,12 +531,11 @@ func (m *Manager) commitAccountTree(slot iotago.SlotIndex, accountDiffChanges ma
 
 		if diffChange.BICChange != 0 || !exists {
 			// decay the credits to the current slot if the account exists
-			if exists {
+			if exists && accountData.Credits.Value > 0 {
 				decayedPreviousCredits, err := m.apiProvider.APIForSlot(slot).ManaDecayProvider().DecayManaBySlots(iotago.Mana(accountData.Credits.Value), accountData.Credits.UpdateSlot, slot)
 				if err != nil {
 					return ierrors.Wrapf(err, "can't retrieve account, could not decay credits for account %s in slot %d", accountData.ID, slot)
 				}
-
 				// update the account data diff taking into account the decay, the modified diff will be stored in the calling
 				// ApplyDiff function to be able to properly rollback the account to a previous slot.
 				diffChange.BICChange -= accountData.Credits.Value - iotago.BlockIssuanceCredits(decayedPreviousCredits)

--- a/pkg/tests/accounts_test.go
+++ b/pkg/tests/accounts_test.go
@@ -464,7 +464,10 @@ func Test_NegativeBIC_BlockIssuerLocked(t *testing.T) {
 				iotago.SlotIndex(0),
 				testsuite.GenesisTimeWithOffsetBySlots(iotago.SlotIndex(200), testsuite.DefaultSlotDurationInSeconds),
 				testsuite.DefaultSlotDurationInSeconds,
-				testsuite.DefaultSlotsPerEpochExponent,
+				3,
+			),
+			iotago.WithLivenessOptions(
+				10, 10, 2, 4, 5,
 			),
 		),
 	)
@@ -588,6 +591,7 @@ func Test_NegativeBIC_BlockIssuerLocked(t *testing.T) {
 	// Allot some mana to the locked account to unlock it.
 	// The locked wallet 2 is preparing and signs the transaction, but it's issued by wallet 1 whose account is not locked.
 	{
+		latestParents = ts.CommitUntilSlot(block3Slot+ts.API.TimeProvider().EpochDurationSlots(), ts.BlockID("block2.1"))
 		allottedBIC := testPayloadCost
 		tx1 := wallet2.AllotManaFromInputs("TX1",
 			iotago.Allotments{&iotago.Allotment{
@@ -608,7 +612,7 @@ func Test_NegativeBIC_BlockIssuerLocked(t *testing.T) {
 
 		ts.AssertAccountData(&accounts.AccountData{
 			ID:              wallet1.BlockIssuer.AccountData.ID,
-			Credits:         accounts.NewBlockIssuanceCredits(wallet1BIC, block3Slot),
+			Credits:         accounts.NewBlockIssuanceCredits(wallet1BIC, block31.ID().Slot()),
 			OutputID:        wallet1OutputID,
 			ExpirySlot:      iotago.MaxSlotIndex,
 			BlockIssuerKeys: wallet1.BlockIssuer.BlockIssuerKeys(),
@@ -616,7 +620,7 @@ func Test_NegativeBIC_BlockIssuerLocked(t *testing.T) {
 
 		ts.AssertAccountData(&accounts.AccountData{
 			ID:              wallet2.BlockIssuer.AccountData.ID,
-			Credits:         accounts.NewBlockIssuanceCredits(wallet2BIC, block3Slot),
+			Credits:         accounts.NewBlockIssuanceCredits(wallet2BIC, block31.ID().Slot()),
 			ExpirySlot:      iotago.MaxSlotIndex,
 			OutputID:        wallet2OutputID,
 			BlockIssuerKeys: wallet2.BlockIssuer.BlockIssuerKeys(),
@@ -639,7 +643,7 @@ func Test_NegativeBIC_BlockIssuerLocked(t *testing.T) {
 
 		ts.AssertAccountData(&accounts.AccountData{
 			ID:              wallet1.BlockIssuer.AccountData.ID,
-			Credits:         accounts.NewBlockIssuanceCredits(wallet1BIC, block3Slot),
+			Credits:         accounts.NewBlockIssuanceCredits(wallet1BIC, ts.BlockID("block3.1").Slot()),
 			OutputID:        wallet1OutputID,
 			ExpirySlot:      iotago.MaxSlotIndex,
 			BlockIssuerKeys: wallet1.BlockIssuer.BlockIssuerKeys(),


### PR DESCRIPTION
Fix BIC underflow observed in alphanet when allotting Mana to an account with negative BIC (see #905).

The problem occurred due to attempting to apply decay to the negative BIC value, where the negative value was simply cast to a uint64 for the decay application, so when comparing the decayed value to the original negative value we get an underflow. 

The solution used here is simply to not decay negative BIC values. It may be more correct to implement some sort of inverse decay function for negative values so debt increases over time, or perhaps to actually decrease debt over time by decaying the absolute value of the debt normally. However, it is sufficient and cleaner to simply leave negative BIC values undecayed for now.

An existing test for negative BIC has been modified to replicate the problem by leaving the negative BIC account for an epoch to decay. This test now passes with this fix.

closes #905 