### PR TITLE
Remove p2p first packet received check

### DIFF
--- a/pkg/network/errors.go
+++ b/pkg/network/errors.go
@@ -11,8 +11,6 @@ var (
 	ErrLoopbackPeer = ierrors.New("loopback connection not allowed")
 	// ErrDuplicatePeer is returned when the same peer is added more than once.
 	ErrDuplicatePeer = ierrors.New("already connected")
-	// ErrFirstPacketNotReceived is returned when the first packet from a peer is not received.
-	ErrFirstPacketNotReceived = ierrors.New("first packet not received")
 	// ErrMaxAutopeeringPeersReached is returned when the maximum number of autopeering peers is reached.
 	ErrMaxAutopeeringPeersReached = ierrors.New("max autopeering peers reached")
 )


### PR DESCRIPTION
This PR removes the check for the "first received packet" in the `addNeighbor` function in the p2p manager.

This was a common cause for node connection problems, especially in the docker network tests. If validator nodes tried to connect to each other and the network was not fully bootstrapped yet, this check often caused the nodes to drop their connection.

We don't need that check anyway, because `addNeighbor` is only called by `DialPeer` or `handleStream` and in both functions we first wait until we received the `Negotiation` package from the other peer.