### PR TITLE
Fix pruning tests

### DIFF
--- a/pkg/network/p2p/manager.go
+++ b/pkg/network/p2p/manager.go
@@ -309,6 +309,13 @@ func (m *Manager) handleStream(stream p2pnetwork.Stream) {
 		return
 	}
 
+	if m.ctx == nil {
+		m.logger.LogDebugf("aborting handling stream, context is nil")
+		m.closeStream(stream)
+
+		return
+	}
+
 	if m.ctx.Err() != nil {
 		m.logger.LogDebugf("aborting handling stream, context is done")
 		m.closeStream(stream)

--- a/pkg/protocol/sybilprotection/sybilprotectionv1/sybilprotection.go
+++ b/pkg/protocol/sybilprotection/sybilprotectionv1/sybilprotection.go
@@ -290,6 +290,7 @@ func (o *SybilProtection) slotFinalized(slot iotago.SlotIndex) {
 		if err != nil {
 			panic(ierrors.Wrap(err, "error while selecting new committee"))
 		}
+		o.LogDebugf("NewCommitteeSelected of size %d", len(newCommittee. IDs()))
 		o.events.CommitteeSelected.Trigger(newCommittee, epoch+1)
 	}
 }

--- a/pkg/protocol/sybilprotection/sybilprotectionv1/sybilprotection.go
+++ b/pkg/protocol/sybilprotection/sybilprotectionv1/sybilprotection.go
@@ -290,7 +290,6 @@ func (o *SybilProtection) slotFinalized(slot iotago.SlotIndex) {
 		if err != nil {
 			panic(ierrors.Wrap(err, "error while selecting new committee"))
 		}
-		o.LogDebugf("NewCommitteeSelected of size %d", len(newCommittee.IDs()))
 		o.events.CommitteeSelected.Trigger(newCommittee, epoch+1)
 	}
 }

--- a/pkg/protocol/sybilprotection/sybilprotectionv1/sybilprotection.go
+++ b/pkg/protocol/sybilprotection/sybilprotectionv1/sybilprotection.go
@@ -290,7 +290,7 @@ func (o *SybilProtection) slotFinalized(slot iotago.SlotIndex) {
 		if err != nil {
 			panic(ierrors.Wrap(err, "error while selecting new committee"))
 		}
-		o.LogDebugf("NewCommitteeSelected of size %d", len(newCommittee. IDs()))
+		o.LogDebugf("NewCommitteeSelected of size %d", len(newCommittee.IDs()))
 		o.events.CommitteeSelected.Trigger(newCommittee, epoch+1)
 	}
 }

--- a/tools/docker-network/tests/api_management_test.go
+++ b/tools/docker-network/tests/api_management_test.go
@@ -260,7 +260,8 @@ func Test_ManagementAPI_Pruning(t *testing.T) {
 
 				// prune database by size
 				pruneDatabaseResponse, err := managementClient.PruneDatabaseBySize(getContextWithTimeout(5*time.Second), "5G")
-				require.ErrorIs(t, err, database.ErrNoPruningNeeded)
+				// Match the error string since the error chain is lost during the HTTP request.
+				require.Contains(t, err.Error(), database.ErrNoPruningNeeded.Error())
 				require.Nil(t, pruneDatabaseResponse)
 			},
 		},

--- a/tools/docker-network/tests/api_management_test.go
+++ b/tools/docker-network/tests/api_management_test.go
@@ -184,13 +184,13 @@ func Test_ManagementAPI_Peers_BadRequests(t *testing.T) {
 func Test_ManagementAPI_Pruning(t *testing.T) {
 	d := NewDockerTestFramework(t,
 		WithProtocolParametersOptions(
-			iotago.WithSupplyOptions(1813620509061365, 63, 1, 4, 0, 0, 0),
-			iotago.WithTimeProviderOptions(0, time.Now().Unix(), 3, 4),
-			iotago.WithLivenessOptions(3, 4, 2, 4, 8),
+			iotago.WithTimeProviderOptions(0, time.Now().Unix(), 4, 4),
+			iotago.WithLivenessOptions(3, 4, 2, 4, 5),
 			iotago.WithCongestionControlOptions(1, 1, 1, 400_000, 250_000, 50_000_000, 1000, 100),
 			iotago.WithRewardsOptions(8, 10, 2, 384),
 			iotago.WithTargetCommitteeSize(4),
-		))
+		),
+	)
 	defer d.Stop()
 
 	d.AddValidatorNode("V1", "docker-network-inx-validator-1-1", "http://localhost:8050", "rms1pzg8cqhfxqhq7pt37y8cs4v5u4kcc48lquy2k73ehsdhf5ukhya3y5rx2w6")
@@ -217,7 +217,7 @@ func Test_ManagementAPI_Pruning(t *testing.T) {
 		currentEpoch := nodeClientV1.CommittedAPI().TimeProvider().EpochFromSlot(info.Status.LatestFinalizedSlot)
 
 		// await the start slot of the next epoch
-		d.AwaitCommitment(nodeClientV1.CommittedAPI().TimeProvider().EpochStart(currentEpoch + 1))
+		d.AwaitFinalization(nodeClientV1.CommittedAPI().TimeProvider().EpochStart(currentEpoch + 1))
 	}
 
 	type test struct {


### PR DESCRIPTION
Fix pruning tests and handle the situation where the context is zero in the peering.

- Use `AwaitFinalization` instead of `AwaitCommitment`.
- Removes the `WithSupplyOptions` option from the network tests since the lack of decay factors cause the BIC of all accounts (including validators) to be decayed to zero at epoch boundaries. Combined with the cost of the candidacy payload this results in negative BIC for the validators making them unable to issue validation blocks starting from the second epoch.
- Match the error string in `Test_PruneDatabase_ByDepth` since the error chain isn't available to match against.

fixes #917