### PR TITLE
Fix: TipSelection (select correct amount of weak and likedInstead parents)

### DIFF
--- a/components/inx/server_issuance.go
+++ b/components/inx/server_issuance.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (s *Server) RequestTips(_ context.Context, req *inx.TipsRequest) (*inx.TipsResponse, error) {
-	references := deps.Protocol.Engines.Main.Get().TipSelection.SelectTips(int(req.GetCount()))
+	references := deps.Protocol.Engines.Main.Get().TipSelection.SelectTips(int(req.GetCount()), int(req.GetCount()), int(req.GetCount()))
 
 	return &inx.TipsResponse{
 		StrongTips:      inx.NewBlockIds(references[iotago.StrongParentType]),

--- a/pkg/protocol/engine/blockdag/inmemoryblockdag/blockdag.go
+++ b/pkg/protocol/engine/blockdag/inmemoryblockdag/blockdag.go
@@ -211,9 +211,9 @@ func (b *BlockDAG) shouldAppend(modelBlock *model.Block) (shouldAppend bool, err
 // canAppendToParents determines if the Block references parents in a non-pruned slot. If a Block is found to violate
 // this condition but exists as a missing entry, we mark it as invalid.
 func (b *BlockDAG) canAppendToParents(modelBlock *model.Block) (parentsValid bool, err error) {
-	for _, parentID := range modelBlock.ProtocolBlock().Parents() {
-		if isBelowRange, isInRange := b.evictionState.BelowOrInActiveRootBlockRange(parentID); isBelowRange || isInRange && !b.evictionState.IsActiveRootBlock(parentID) {
-			return false, ierrors.Errorf("parent %s of block %s is too old", parentID, modelBlock.ID())
+	for _, parent := range modelBlock.ProtocolBlock().ParentsWithType() {
+		if isBelowRange, isInRange := b.evictionState.BelowOrInActiveRootBlockRange(parent.ID); isBelowRange || isInRange && !b.evictionState.IsActiveRootBlock(parent.ID) {
+			return false, ierrors.Errorf("parent %s with type %s of block %s is too old", parent.ID, parent.Type, modelBlock.ID())
 		}
 	}
 

--- a/pkg/protocol/engine/tipselection/tipselection.go
+++ b/pkg/protocol/engine/tipselection/tipselection.go
@@ -10,7 +10,7 @@ import (
 // TipSelection is a component that is used to abstract away the tip selection strategy, used to issuing new blocks.
 type TipSelection interface {
 	// SelectTips selects the tips that should be used as references for a new block.
-	SelectTips(count int) (references model.ParentReferences)
+	SelectTips(maxStrongParents int, maxLikedInsteadParents int, maxWeakParents int) (references model.ParentReferences)
 
 	// SetAcceptanceTime updates the acceptance time of the TipSelection.
 	SetAcceptanceTime(acceptanceTime time.Time) (previousTime time.Time)

--- a/pkg/protocol/engine/tipselection/v1/tip_selection.go
+++ b/pkg/protocol/engine/tipselection/v1/tip_selection.go
@@ -101,10 +101,10 @@ func (t *TipSelection) SelectTips(maxStrongParents int, maxLikedInsteadParents i
 		previousLikedInsteadConflicts := ds.NewSet[iotago.TransactionID]()
 
 		if t.collectReferences(func(tip tipmanager.TipMetadata) {
-			addedLikedInsteadReferences, updatedLikedInsteadConflicts, err := t.likedInsteadReferences(maxLikedInsteadReferencesPerParent, previousLikedInsteadConflicts, tip)
-			if err != nil {
+			switch addedLikedInsteadReferences, updatedLikedInsteadConflicts, err := t.likedInsteadReferences(maxLikedInsteadReferencesPerParent, previousLikedInsteadConflicts, tip); {
+			case err != nil:
 				tip.TipPool().Set(tipmanager.WeakTipPool)
-			} else if len(addedLikedInsteadReferences) <= maxLikedInsteadParents-len(references[iotago.ShallowLikeParentType]) {
+			case len(addedLikedInsteadReferences) <= maxLikedInsteadParents-len(references[iotago.ShallowLikeParentType]):
 				references[iotago.StrongParentType] = append(references[iotago.StrongParentType], tip.ID())
 				references[iotago.ShallowLikeParentType] = append(references[iotago.ShallowLikeParentType], addedLikedInsteadReferences...)
 
@@ -112,7 +112,7 @@ func (t *TipSelection) SelectTips(maxStrongParents int, maxLikedInsteadParents i
 				strongParents.Add(tip.ID())
 
 				previousLikedInsteadConflicts = updatedLikedInsteadConflicts
-			} else {
+			default:
 				t.LogTrace("could not add liked instead references to tip", "tip", tip.ID(), "addedLikedInsteadReferences", addedLikedInsteadReferences)
 			}
 		}, func() int {

--- a/pkg/requesthandler/blocks.go
+++ b/pkg/requesthandler/blocks.go
@@ -61,7 +61,7 @@ func (r *RequestHandler) BlockWithMetadataFromBlockID(blockID iotago.BlockID) (*
 }
 
 func (r *RequestHandler) BlockIssuance() (*api.IssuanceBlockHeaderResponse, error) {
-	references := r.protocol.Engines.Main.Get().TipSelection.SelectTips(iotago.BasicBlockMaxParents)
+	references := r.protocol.Engines.Main.Get().TipSelection.SelectTips(iotago.BasicBlockMaxParents, iotago.BasicBlockMaxParents, iotago.BasicBlockMaxParents)
 	if len(references[iotago.StrongParentType]) == 0 {
 		return nil, ierrors.WithMessage(echo.ErrServiceUnavailable, "no strong parents available")
 	}

--- a/tools/genesis-snapshot/presets/presets.go
+++ b/tools/genesis-snapshot/presets/presets.go
@@ -21,6 +21,7 @@ var (
 	// use defaults from iota.go.
 	ProtocolParamsBase = iotago.NewV3SnapshotProtocolParameters(
 		iotago.WithNetworkOptions("default", iotago.PrefixTestnet),
+		iotago.WithChainSwitchingThreshold(10),
 	)
 
 	// use defaults from iota.go.
@@ -28,12 +29,14 @@ var (
 		iotago.WithNetworkOptions(fmt.Sprintf("docker-%d", time.Now().Unix()), iotago.PrefixTestnet),
 		iotago.WithTimeProviderOptions(5, time.Now().Unix(), 10, 13),
 		iotago.WithLivenessOptions(10, 15, 3, 6, 8),
+		iotago.WithChainSwitchingThreshold(10),
 	)
 
 	// use defaults from iota.go.
 	ProtocolParamsFeature = iotago.NewV3SnapshotProtocolParameters(
 		iotago.WithNetworkOptions(fmt.Sprintf("feature-%d", time.Now().Unix()), iotago.PrefixTestnet),
 		iotago.WithTimeProviderOptions(666666, time.Now().Unix()-100_000, 10, 13),
+		iotago.WithChainSwitchingThreshold(10),
 	)
 )
 


### PR DESCRIPTION
This PR updates the TipSelection to correctly select different amounts of weak and likedInstead parents based on the block type and introduces some debug logs in the TipSelection to find the cause for a possibly remaining problem in the tip selection.