### PR TITLE
Fix Docker Network Tests

### DIFF
--- a/tools/docker-network/tests/api_management_test.go
+++ b/tools/docker-network/tests/api_management_test.go
@@ -214,7 +214,7 @@ func Test_ManagementAPI_Pruning(t *testing.T) {
 		info, err := nodeClientV1.Info(getContextWithTimeout(5 * time.Second))
 		require.NoError(t, err)
 
-		currentEpoch := nodeClientV1.CommittedAPI().TimeProvider().EpochFromSlot(info.Status.LatestCommitmentID.Slot())
+		currentEpoch := nodeClientV1.CommittedAPI().TimeProvider().EpochFromSlot(info.Status.LatestFinalizedSlot)
 
 		// await the start slot of the next epoch
 		d.AwaitFinalization(nodeClientV1.CommittedAPI().TimeProvider().EpochStart(currentEpoch + 1))

--- a/tools/docker-network/tests/dockerframework.go
+++ b/tools/docker-network/tests/dockerframework.go
@@ -686,7 +686,10 @@ func (d *DockerTestFramework) AllotManaTo(fromWallet *mock.Wallet, to *mock.Acco
 	toCongestionResp, err = clt.Congestion(ctx, to.Address, 0)
 	require.NoError(d.Testing, err)
 	newBIC := toCongestionResp.BlockIssuanceCredits
-	require.Equal(d.Testing, oldBIC+iotago.BlockIssuanceCredits(manaToAllot), newBIC)
+
+	decayedOldBIC, err := clt.LatestAPI().ManaDecayProvider().DecayManaBySlots(iotago.Mana(oldBIC), preAllotmentCommitmentID.Slot(), block.ID().Slot())
+	expectedBIC := iotago.BlockIssuanceCredits(decayedOldBIC + manaToAllot)
+	require.Equal(d.Testing, expectedBIC, newBIC)
 }
 
 // CreateNativeToken request faucet funds then use it to create native token for the account, and returns the updated Account.


### PR DESCRIPTION
A few small fixes for docker network tests.

Account transition test required decay to be applied in case there is a change of epoch during the test.

ManagementAPI tests had a fix removed accidentally which is now corrected.