### PR TITLE
fix underflows in rewards tests waiting

### DIFF
--- a/tools/docker-network/tests/utils.go
+++ b/tools/docker-network/tests/utils.go
@@ -119,10 +119,12 @@ func (d *DockerTestFramework) AssertCommittee(expectedEpoch iotago.EpochIndex, e
 	expectedSlotStart := testAPI.TimeProvider().EpochStart(expectedEpoch)
 	require.Greater(d.Testing, expectedSlotStart, status.LatestAcceptedBlockSlot)
 
-	slotToWait := expectedSlotStart - status.LatestAcceptedBlockSlot
-	secToWait := time.Duration(slotToWait) * time.Duration(testAPI.ProtocolParameters().SlotDurationInSeconds()) * time.Second
-	fmt.Println("Wait for ", secToWait, "until expected epoch: ", expectedEpoch)
-	time.Sleep(secToWait)
+	if status.LatestAcceptedBlockSlot < expectedSlotStart {
+		slotToWait := expectedSlotStart - status.LatestAcceptedBlockSlot
+		secToWait := time.Duration(slotToWait) * time.Duration(testAPI.ProtocolParameters().SlotDurationInSeconds()) * time.Second
+		fmt.Println("Wait for ", secToWait, "until expected epoch: ", expectedEpoch)
+		time.Sleep(secToWait)
+	}
 
 	d.Eventually(func() error {
 		for _, node := range d.Nodes() {


### PR DESCRIPTION
Fix underflow which sometimes occurs in docker network tests when calculating wait times until some expected slot.

![Screenshot 2024-04-24 at 16 07 06](https://github.com/iotaledger/iota-core/assets/45826600/3f6fd2c9-3af7-454b-b413-fa7012bcb6b4)
