### PR TITLE
Fix: Only request Attestations when parent of forking point is verified

### DIFF
--- a/pkg/protocol/chain.go
+++ b/pkg/protocol/chain.go
@@ -57,9 +57,6 @@ type Chain struct {
 	// IsEvicted contains a flag that indicates whether this chain was evicted.
 	IsEvicted reactive.Event
 
-	// IsSolid contains a flag that indicates whether this chain is solid (has a continuous connection to the root).
-	IsSolid reactive.Event
-
 	// shouldEvict contains a flag that indicates whether this chain should be evicted.
 	shouldEvict reactive.Event
 
@@ -89,7 +86,6 @@ func newChain(chains *Chains) *Chain {
 		StartEngine:              reactive.NewVariable[bool](),
 		Engine:                   reactive.NewVariable[*engine.Engine](),
 		IsEvicted:                reactive.NewEvent(),
-		IsSolid:                  reactive.NewEvent(),
 		shouldEvict:              reactive.NewEvent(),
 
 		chains:      chains,
@@ -213,7 +209,6 @@ func (c *Chain) initLogger() (shutdown func()) {
 		c.StartEngine.LogUpdates(c, log.LevelDebug, "StartEngine"),
 		c.Engine.LogUpdates(c, log.LevelTrace, "Engine", (*engine.Engine).LogName),
 		c.IsEvicted.LogUpdates(c, log.LevelTrace, "IsEvicted"),
-		c.IsSolid.LogUpdates(c, log.LevelTrace, "IsSolid"),
 		c.shouldEvict.LogUpdates(c, log.LevelTrace, "shouldEvict"),
 
 		c.Logger.Shutdown,
@@ -237,8 +232,6 @@ func (c *Chain) initDerivedProperties() (shutdown func()) {
 							c.deriveShouldEvict(forkingPoint, parentChain),
 						)
 					}),
-
-					c.IsSolid.InheritFrom(forkingPoint.IsSolid),
 				)
 			}),
 		),

--- a/pkg/protocol/chains.go
+++ b/pkg/protocol/chains.go
@@ -323,8 +323,12 @@ func (c *Chains) initChainSwitching() (shutdown func()) {
 
 	return lo.BatchReverse(
 		c.HeaviestClaimedCandidate.WithNonEmptyValue(func(heaviestClaimedCandidate *Chain) (shutdown func()) {
-			return heaviestClaimedCandidate.IsSolid.WithNonEmptyValue(func(_ bool) (teardown func()) {
-				return heaviestClaimedCandidate.RequestAttestations.ToggleValue(true)
+			return heaviestClaimedCandidate.ForkingPoint.WithNonEmptyValue(func(forkingPoint *Commitment) (teardown func()) {
+				return forkingPoint.Parent.WithNonEmptyValue(func(parentOfForkingPoint *Commitment) (teardown func()) {
+					return parentOfForkingPoint.IsVerified.WithNonEmptyValue(func(_ bool) (teardown func()) {
+						return heaviestClaimedCandidate.RequestAttestations.ToggleValue(true)
+					})
+				})
 			})
 		}),
 

--- a/pkg/protocol/commitment.go
+++ b/pkg/protocol/commitment.go
@@ -60,10 +60,6 @@ type Commitment struct {
 	// IsRoot contains a flag indicating if this Commitment is the root of the Chain.
 	IsRoot reactive.Event
 
-	// IsSolid contains a flag indicating if this Commitment is solid (has all the commitments in its past cone until
-	// the RootCommitment).
-	IsSolid reactive.Event
-
 	// IsAttested contains a flag indicating if we have received attestations for this Commitment.
 	IsAttested reactive.Event
 
@@ -112,7 +108,6 @@ func newCommitment(commitments *Commitments, model *model.Commitment) *Commitmen
 		CumulativeAttestedWeight:        reactive.NewVariable[uint64](),
 		CumulativeVerifiedWeight:        reactive.NewVariable[uint64](),
 		IsRoot:                          reactive.NewEvent(),
-		IsSolid:                         reactive.NewEvent(),
 		IsAttested:                      reactive.NewEvent(),
 		IsSynced:                        reactive.NewEvent(),
 		IsCommittable:                   reactive.NewEvent(),
@@ -224,7 +219,6 @@ func (c *Commitment) initLogger() (shutdown func()) {
 		c.CumulativeAttestedWeight.LogUpdates(c, log.LevelTrace, "CumulativeAttestedWeight"),
 		c.CumulativeVerifiedWeight.LogUpdates(c, log.LevelTrace, "CumulativeVerifiedWeight"),
 		c.IsRoot.LogUpdates(c, log.LevelTrace, "IsRoot"),
-		c.IsSolid.LogUpdates(c, log.LevelTrace, "IsSolid"),
 		c.IsAttested.LogUpdates(c, log.LevelTrace, "IsAttested"),
 		c.IsSynced.LogUpdates(c, log.LevelTrace, "IsSynced"),
 		c.IsCommittable.LogUpdates(c, log.LevelTrace, "IsCommittable"),
@@ -241,7 +235,6 @@ func (c *Commitment) initDerivedProperties() (shutdown func()) {
 	return lo.BatchReverse(
 		// mark commitments that are marked as root as verified
 		c.IsVerified.InheritFrom(c.IsRoot),
-		c.IsSolid.InheritFrom(c.IsRoot),
 
 		c.IsRoot.OnTrigger(func() {
 			c.CumulativeAttestedWeight.Set(c.Commitment.CumulativeWeight())
@@ -277,8 +270,6 @@ func (c *Commitment) initDerivedProperties() (shutdown func()) {
 						}),
 					)
 				}),
-
-				c.IsSolid.InheritFrom(parent.IsSolid),
 			)
 		}),
 


### PR DESCRIPTION
This PR changes the logic to only request attestations if the parent of the forkingpoint was verified.

This ensures that we have the latest state in the parent engine (i.e. for the committees) to validate the attestations.