### PR TITLE
Fix: Tiebreaker for chains with equal weight

### DIFF
--- a/pkg/protocol/chains.go
+++ b/pkg/protocol/chains.go
@@ -323,13 +323,7 @@ func (c *Chains) initChainSwitching() (shutdown func()) {
 
 	return lo.BatchReverse(
 		c.HeaviestClaimedCandidate.WithNonEmptyValue(func(heaviestClaimedCandidate *Chain) (shutdown func()) {
-			return heaviestClaimedCandidate.ForkingPoint.WithNonEmptyValue(func(forkingPoint *Commitment) (teardown func()) {
-				return forkingPoint.Parent.WithNonEmptyValue(func(parentOfForkingPoint *Commitment) (teardown func()) {
-					return parentOfForkingPoint.IsVerified.WithNonEmptyValue(func(_ bool) (teardown func()) {
-						return heaviestClaimedCandidate.RequestAttestations.ToggleValue(true)
-					})
-				})
-			})
+			return heaviestClaimedCandidate.RequestAttestations.ToggleValue(true)
 		}),
 
 		c.HeaviestAttestedCandidate.OnUpdate(func(_ *Chain, heaviestAttestedCandidate *Chain) {
@@ -351,7 +345,7 @@ func (c *Chains) initChainSwitching() (shutdown func()) {
 
 func (c *Chains) trackHeaviestCandidates(chain *Chain) (teardown func()) {
 	return chain.LatestCommitment.OnUpdate(func(_ *Commitment, latestCommitment *Commitment) {
-		chain.IsSolid.OnTrigger(func() {
+		chain.DivergencePointVerified.OnTrigger(func() {
 			targetSlot := latestCommitment.ID().Index()
 
 			if evictionEvent := c.protocol.EvictionEvent(targetSlot); !evictionEvent.WasTriggered() {

--- a/pkg/protocol/chains.go
+++ b/pkg/protocol/chains.go
@@ -351,19 +351,21 @@ func (c *Chains) initChainSwitching() (shutdown func()) {
 
 func (c *Chains) trackHeaviestCandidates(chain *Chain) (teardown func()) {
 	return chain.LatestCommitment.OnUpdate(func(_ *Commitment, latestCommitment *Commitment) {
-		targetSlot := latestCommitment.ID().Index()
+		chain.IsSolid.OnTrigger(func() {
+			targetSlot := latestCommitment.ID().Index()
 
-		if evictionEvent := c.protocol.EvictionEvent(targetSlot); !evictionEvent.WasTriggered() {
-			c.HeaviestClaimedCandidate.registerCommitment(targetSlot, latestCommitment, evictionEvent)
+			if evictionEvent := c.protocol.EvictionEvent(targetSlot); !evictionEvent.WasTriggered() {
+				c.HeaviestClaimedCandidate.registerCommitment(targetSlot, latestCommitment, evictionEvent)
 
-			latestCommitment.IsAttested.OnTrigger(func() {
-				c.HeaviestAttestedCandidate.registerCommitment(targetSlot, latestCommitment, evictionEvent)
-			})
+				latestCommitment.IsAttested.OnTrigger(func() {
+					c.HeaviestAttestedCandidate.registerCommitment(targetSlot, latestCommitment, evictionEvent)
+				})
 
-			latestCommitment.IsVerified.OnTrigger(func() {
-				c.HeaviestVerifiedCandidate.registerCommitment(targetSlot, latestCommitment, evictionEvent)
-			})
-		}
+				latestCommitment.IsVerified.OnTrigger(func() {
+					c.HeaviestVerifiedCandidate.registerCommitment(targetSlot, latestCommitment, evictionEvent)
+				})
+			}
+		})
 	})
 }
 


### PR DESCRIPTION
This PR fixes a problem with the tie breaker for chains with equal weight, by waiting with registering the commitments until their divergence point is verified.

Otherwise it might happen, that we try to access data about our forking point and chain that is still unknown during the sync process. This currently prevents the chain switching from working.