### PR TITLE
Fix: Prevent spawning of unnecessary chains

### DIFF
--- a/pkg/protocol/commitment.go
+++ b/pkg/protocol/commitment.go
@@ -93,7 +93,7 @@ type Commitment struct {
 
 // NewCommitment creates a new Commitment from the given model.Commitment.
 func newCommitment(commitments *Commitments, model *model.Commitment) *Commitment {
-	c := &Commitment{
+	return &Commitment{
 		Commitment:                      model,
 		Parent:                          reactive.NewVariable[*Commitment](),
 		Children:                        reactive.NewSet[*Commitment](),
@@ -117,15 +117,6 @@ func newCommitment(commitments *Commitments, model *model.Commitment) *Commitmen
 		IsEvicted:                       reactive.NewEvent(),
 		commitments:                     commitments,
 	}
-
-	shutdown := lo.BatchReverse(
-		c.initLogger(),
-		c.initDerivedProperties(),
-	)
-
-	c.IsEvicted.OnTrigger(shutdown)
-
-	return c
 }
 
 // TargetEngine returns the engine that is responsible for booking the blocks of this Commitment.
@@ -201,6 +192,16 @@ func (c *Commitment) Less(other *Commitment) bool {
 			}
 		}
 	}
+}
+
+// initBehavior initializes the behavior of this Commitment by setting up the relations between its properties.
+func (c *Commitment) initBehavior() {
+	shutdown := lo.BatchReverse(
+		c.initLogger(),
+		c.initDerivedProperties(),
+	)
+
+	c.IsEvicted.OnTrigger(shutdown)
 }
 
 // initLogger initializes the Logger of this Commitment.

--- a/pkg/protocol/commitment.go
+++ b/pkg/protocol/commitment.go
@@ -116,6 +116,7 @@ func newCommitment(commitments *Commitments, model *model.Commitment) *Commitmen
 		ReplayDroppedBlocks:             reactive.NewVariable[bool](),
 		IsEvicted:                       reactive.NewEvent(),
 		commitments:                     commitments,
+		Logger:                          commitments.NewChildLogger(fmt.Sprintf("Slot%d.", model.Slot()), true),
 	}
 }
 
@@ -206,8 +207,6 @@ func (c *Commitment) initBehavior() {
 
 // initLogger initializes the Logger of this Commitment.
 func (c *Commitment) initLogger() (shutdown func()) {
-	c.Logger = c.commitments.NewChildLogger(fmt.Sprintf("Slot%d.", c.Slot()), true)
-
 	return lo.BatchReverse(
 		c.Parent.LogUpdates(c, log.LevelTrace, "Parent", (*Commitment).LogName),
 		c.MainChild.LogUpdates(c, log.LevelTrace, "MainChild", (*Commitment).LogName),

--- a/pkg/protocol/commitments.go
+++ b/pkg/protocol/commitments.go
@@ -187,18 +187,24 @@ func (c *Commitments) publishEngineCommitments(chain *Chain, engine *engine.Engi
 			}
 
 			// publish the commitment
-			publishedCommitment, _, err := c.publishCommitment(commitment)
+			publishedCommitment, published, err := c.publishCommitment(commitment, true)
 			if err != nil {
 				c.LogError("failed to publish commitment from engine", "engine", engine.LogName(), "commitment", commitment, "err", err)
 
 				return
 			}
 
+			// force the chain before initializing the commitment manually to prevent the creation of unnecessary chains
+			publishedCommitment.forceChain(chain)
+			if published {
+				publishedCommitment.initBehavior()
+			}
+
 			// mark it as produced by ourselves and force it to be on the right chain (in case our chain produced a
 			// different commitment than the one we erroneously expected it to be - we always trust our engine most).
 			publishedCommitment.AttestedWeight.Set(publishedCommitment.Weight.Get())
 			publishedCommitment.IsVerified.Set(true)
-			publishedCommitment.forceChain(chain)
+
 		}
 	})
 }

--- a/pkg/protocol/commitments.go
+++ b/pkg/protocol/commitments.go
@@ -204,7 +204,6 @@ func (c *Commitments) publishEngineCommitments(chain *Chain, engine *engine.Engi
 			// different commitment than the one we erroneously expected it to be - we always trust our engine most).
 			publishedCommitment.AttestedWeight.Set(publishedCommitment.Weight.Get())
 			publishedCommitment.IsVerified.Set(true)
-
 		}
 	})
 }

--- a/pkg/protocol/commitments.go
+++ b/pkg/protocol/commitments.go
@@ -221,10 +221,11 @@ func (c *Commitments) publishCommitment(commitment *model.Commitment, initManual
 	// otherwise try to publish it and determine if we were the goroutine that published it
 	cachedRequest.ResolveDynamically(func() *Commitment {
 		publishedCommitment = newCommitment(c, commitment)
+		published = true
+
 		if !lo.First(initManually) {
 			publishedCommitment.initBehavior()
 		}
-		published = true
 
 		return publishedCommitment
 	})

--- a/pkg/protocol/commitments.go
+++ b/pkg/protocol/commitments.go
@@ -194,7 +194,7 @@ func (c *Commitments) publishEngineCommitments(chain *Chain, engine *engine.Engi
 				return
 			}
 
-			// force the chain before initializing the commitment manually to prevent the creation of unnecessary chains
+			// force the chain before initializing the behavior to prevent the creation of unnecessary chains
 			publishedCommitment.forceChain(chain)
 			if published {
 				publishedCommitment.initBehavior()


### PR DESCRIPTION
This PR build on top of: https://github.com/iotaledger/iota-core/pull/939 and fixes a problem where we created a short living chain for newly produced engine commitments that replace an already existing commitment extending the same chain.

The problem is fixed by registering ourselves as the main child of our parent (forceChain) before we initialize the behavior of the commitment (so it doesn't prematurely determine its chain).