### PR TITLE
Feat: Adjust log levels to more sane DEBUG defaults

### DIFF
--- a/pkg/protocol/chain.go
+++ b/pkg/protocol/chain.go
@@ -201,7 +201,7 @@ func (c *Chain) initLogger() (shutdown func()) {
 	c.Logger = c.chains.NewChildLogger("", true)
 
 	return lo.BatchReverse(
-		c.WarpSyncMode.LogUpdates(c, log.LevelTrace, "WarpSyncMode"),
+		c.WarpSyncMode.LogUpdates(c, log.LevelDebug, "WarpSyncMode"),
 		c.LatestSyncedSlot.LogUpdates(c, log.LevelTrace, "LatestSyncedSlot"),
 		c.OutOfSyncThreshold.LogUpdates(c, log.LevelTrace, "OutOfSyncThreshold"),
 		c.ForkingPoint.LogUpdates(c, log.LevelTrace, "ForkingPoint", (*Commitment).LogName),

--- a/pkg/protocol/chains.go
+++ b/pkg/protocol/chains.go
@@ -87,9 +87,9 @@ func (c *Chains) initLogger(logger log.Logger) (shutdown func()) {
 
 	return lo.BatchReverse(
 		c.Main.LogUpdates(c, log.LevelTrace, "Main", (*Chain).LogName),
-		c.HeaviestClaimedCandidate.LogUpdates(c, log.LevelTrace, "HeaviestClaimedCandidate", (*Chain).LogName),
-		c.HeaviestAttestedCandidate.LogUpdates(c, log.LevelTrace, "HeaviestAttestedCandidate", (*Chain).LogName),
-		c.HeaviestVerifiedCandidate.LogUpdates(c, log.LevelTrace, "HeaviestVerifiedCandidate", (*Chain).LogName),
+		c.HeaviestClaimedCandidate.LogUpdates(c, log.LevelDebug, "HeaviestClaimedCandidate", (*Chain).LogName),
+		c.HeaviestAttestedCandidate.LogUpdates(c, log.LevelDebug, "HeaviestAttestedCandidate", (*Chain).LogName),
+		c.HeaviestVerifiedCandidate.LogUpdates(c, log.LevelDebug, "HeaviestVerifiedCandidate", (*Chain).LogName),
 
 		logger.Shutdown,
 	)

--- a/pkg/protocol/chains.go
+++ b/pkg/protocol/chains.go
@@ -2,7 +2,6 @@ package protocol
 
 import (
 	"cmp"
-	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
@@ -10,14 +9,8 @@ import (
 	"github.com/iotaledger/hive.go/ds/shrinkingmap"
 	"github.com/iotaledger/hive.go/lo"
 	"github.com/iotaledger/hive.go/log"
-	"github.com/iotaledger/iota-core/pkg/core/account"
 	"github.com/iotaledger/iota-core/pkg/model"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine"
-	"github.com/iotaledger/iota-core/pkg/protocol/engine/blocks"
-	"github.com/iotaledger/iota-core/pkg/protocol/engine/filter/postsolidfilter"
-	"github.com/iotaledger/iota-core/pkg/protocol/engine/filter/presolidfilter"
-	"github.com/iotaledger/iota-core/pkg/protocol/engine/mempool"
-	"github.com/iotaledger/iota-core/pkg/protocol/engine/notarization"
 	iotago "github.com/iotaledger/iota.go/v4"
 )
 
@@ -64,16 +57,6 @@ func newChains(protocol *Protocol) *Chains {
 	c.HeaviestAttestedCandidate = newChainsCandidate(c, (*Commitment).cumulativeAttestedWeight)
 	c.HeaviestVerifiedCandidate = newChainsCandidate(c, (*Commitment).cumulativeVerifiedWeight)
 
-	c.WithElements(func(chain *Chain) (teardown func()) {
-		return chain.Engine.OnUpdate(func(_ *engine.Engine, newEngine *engine.Engine) {
-			if newEngine != nil {
-				newEngine.OnLogLevelActive(log.LevelTrace, func() (shutdown func()) {
-					return attachEngineLogs(newEngine)
-				})
-			}
-		})
-	})
-
 	shutdown := lo.BatchReverse(
 		c.initLogger(protocol.NewChildLogger("Chains")),
 		c.initChainSwitching(),
@@ -86,208 +69,6 @@ func newChains(protocol *Protocol) *Chains {
 	protocol.ShutdownEvent().OnTrigger(shutdown)
 
 	return c
-}
-
-func attachEngineLogs(instance *engine.Engine) func() {
-	events := instance.Events
-
-	return lo.BatchReverse(
-		events.BlockDAG.BlockAppended.Hook(func(block *blocks.Block) {
-			instance.LogTrace("BlockDAG.BlockAppended", "block", block.ID())
-		}).Unhook,
-
-		events.BlockDAG.BlockSolid.Hook(func(block *blocks.Block) {
-			instance.LogTrace("BlockDAG.BlockSolid", "block", block.ID())
-		}).Unhook,
-
-		events.BlockDAG.BlockInvalid.Hook(func(block *blocks.Block, err error) {
-			instance.LogTrace("BlockDAG.BlockInvalid", "block", block.ID(), "err", err)
-		}).Unhook,
-
-		events.BlockDAG.BlockMissing.Hook(func(block *blocks.Block) {
-			instance.LogTrace("BlockDAG.BlockMissing", "block", block.ID())
-		}).Unhook,
-
-		events.BlockDAG.MissingBlockAppended.Hook(func(block *blocks.Block) {
-			instance.LogTrace("BlockDAG.MissingBlockAppended", "block", block.ID())
-		}).Unhook,
-
-		events.SeatManager.BlockProcessed.Hook(func(block *blocks.Block) {
-			instance.LogTrace("SeatManager.BlockProcessed", "block", block.ID())
-		}).Unhook,
-
-		events.Booker.BlockBooked.Hook(func(block *blocks.Block) {
-			instance.LogTrace("Booker.BlockBooked", "block", block.ID())
-		}).Unhook,
-
-		events.Booker.BlockInvalid.Hook(func(block *blocks.Block, err error) {
-			instance.LogTrace("Booker.BlockInvalid", "block", block.ID(), "err", err)
-		}).Unhook,
-
-		events.Booker.TransactionInvalid.Hook(func(metadata mempool.TransactionMetadata, err error) {
-			instance.LogTrace("Booker.TransactionInvalid", "tx", metadata.ID(), "err", err)
-		}).Unhook,
-
-		events.Scheduler.BlockScheduled.Hook(func(block *blocks.Block) {
-			instance.LogTrace("Scheduler.BlockScheduled", "block", block.ID())
-		}).Unhook,
-
-		events.Scheduler.BlockEnqueued.Hook(func(block *blocks.Block) {
-			instance.LogTrace("Scheduler.BlockEnqueued", "block", block.ID())
-		}).Unhook,
-
-		events.Scheduler.BlockSkipped.Hook(func(block *blocks.Block) {
-			instance.LogTrace("Scheduler.BlockSkipped", "block", block.ID())
-		}).Unhook,
-
-		events.Scheduler.BlockDropped.Hook(func(block *blocks.Block, err error) {
-			instance.LogTrace("Scheduler.BlockDropped", "block", block.ID(), "err", err)
-		}).Unhook,
-
-		events.Clock.AcceptedTimeUpdated.Hook(func(newTime time.Time) {
-			instance.LogTrace("Clock.AcceptedTimeUpdated", "time", newTime, "slot", instance.LatestAPI().TimeProvider().SlotFromTime(newTime))
-		}).Unhook,
-
-		events.Clock.ConfirmedTimeUpdated.Hook(func(newTime time.Time) {
-			instance.LogTrace("Clock.ConfirmedTimeUpdated", "time", newTime, "slot", instance.LatestAPI().TimeProvider().SlotFromTime(newTime))
-		}).Unhook,
-
-		events.PreSolidFilter.BlockPreAllowed.Hook(func(block *model.Block) {
-			instance.LogTrace("PreSolidFilter.BlockPreAllowed", "block", block.ID())
-		}).Unhook,
-
-		events.PreSolidFilter.BlockPreFiltered.Hook(func(event *presolidfilter.BlockPreFilteredEvent) {
-			instance.LogTrace("PreSolidFilter.BlockPreFiltered", "block", event.Block.ID(), "err", event.Reason)
-		}).Unhook,
-
-		events.PostSolidFilter.BlockAllowed.Hook(func(block *blocks.Block) {
-			instance.LogTrace("PostSolidFilter.BlockAllowed", "block", block.ID())
-		}).Unhook,
-
-		events.PostSolidFilter.BlockFiltered.Hook(func(event *postsolidfilter.BlockFilteredEvent) {
-			instance.LogTrace("PostSolidFilter.BlockFiltered", "block", event.Block.ID(), "err", event.Reason)
-		}).Unhook,
-
-		events.BlockRequester.Tick.Hook(func(blockID iotago.BlockID) {
-			instance.LogTrace("BlockRequester.Tick", "block", blockID)
-		}).Unhook,
-
-		events.BlockProcessed.Hook(func(blockID iotago.BlockID) {
-			instance.LogTrace("BlockProcessed", "block", blockID)
-		}).Unhook,
-
-		events.BlockRetainer.BlockRetained.Hook(func(block *blocks.Block) {
-			instance.LogTrace("Retainer.BlockRetained", "block", block.ID())
-		}).Unhook,
-
-		events.TransactionRetainer.TransactionRetained.Hook(func(txID iotago.TransactionID) {
-			instance.LogTrace("Retainer.TransactionRetained", "transaction", txID)
-		}).Unhook,
-
-		events.Notarization.SlotCommitted.Hook(func(details *notarization.SlotCommittedDetails) {
-			instance.LogDebug("NotarizationManager.SlotCommitted", "commitment", details.Commitment.ID(), "acceptedBlocks count", details.AcceptedBlocks.Size(), "accepted transactions", len(details.Mutations))
-		}).Unhook,
-
-		events.Notarization.LatestCommitmentUpdated.Hook(func(commitment *model.Commitment) {
-			instance.LogDebug("NotarizationManager.LatestCommitmentUpdated", "commitment", commitment.ID())
-		}).Unhook,
-
-		events.BlockGadget.BlockPreAccepted.Hook(func(block *blocks.Block) {
-			instance.LogTrace("BlockGadget.BlockPreAccepted", "block", block.ID(), "slotCommitmentID", block.ProtocolBlock().Header.SlotCommitmentID)
-		}).Unhook,
-
-		events.BlockGadget.BlockAccepted.Hook(func(block *blocks.Block) {
-			instance.LogTrace("BlockGadget.BlockAccepted", "block", block.ID(), "slotCommitmentID", block.ProtocolBlock().Header.SlotCommitmentID)
-		}).Unhook,
-
-		events.BlockGadget.BlockPreConfirmed.Hook(func(block *blocks.Block) {
-			instance.LogTrace("BlockGadget.BlockPreConfirmed", "block", block.ID(), "slotCommitmentID", block.ProtocolBlock().Header.SlotCommitmentID)
-		}).Unhook,
-
-		events.BlockGadget.BlockConfirmed.Hook(func(block *blocks.Block) {
-			instance.LogTrace("BlockGadget.BlockConfirmed", "block", block.ID(), "slotCommitmentID", block.ProtocolBlock().Header.SlotCommitmentID)
-		}).Unhook,
-
-		events.SlotGadget.SlotFinalized.Hook(func(slot iotago.SlotIndex) {
-			instance.LogDebug("SlotGadget.SlotFinalized", "slot", slot)
-		}).Unhook,
-
-		events.SeatManager.OnlineCommitteeSeatAdded.Hook(func(seat account.SeatIndex, accountID iotago.AccountID) {
-			instance.LogInfo("SybilProtection.OnlineCommitteeSeatAdded", "seat", seat, "accountID", accountID)
-		}).Unhook,
-
-		events.SeatManager.OnlineCommitteeSeatRemoved.Hook(func(seat account.SeatIndex) {
-			instance.LogInfo("SybilProtection.OnlineCommitteeSeatRemoved", "seat", seat)
-		}).Unhook,
-
-		events.SybilProtection.CommitteeSelected.Hook(func(committee *account.SeatedAccounts, epoch iotago.EpochIndex) {
-			instance.LogInfo("SybilProtection.CommitteeSelected", "epoch", epoch, "committee", committee.IDs())
-		}).Unhook,
-
-		events.SpendDAG.SpenderCreated.Hook(func(conflictID iotago.TransactionID) {
-			instance.LogTrace("SpendDAG.SpenderCreated", "conflictID", conflictID)
-		}).Unhook,
-
-		events.SpendDAG.SpenderEvicted.Hook(func(conflictID iotago.TransactionID) {
-			instance.LogTrace("SpendDAG.SpenderEvicted", "conflictID", conflictID)
-		}).Unhook,
-
-		events.SpendDAG.SpenderRejected.Hook(func(conflictID iotago.TransactionID) {
-			instance.LogTrace("SpendDAG.SpenderRejected", "conflictID", conflictID)
-		}).Unhook,
-
-		events.SpendDAG.SpenderAccepted.Hook(func(conflictID iotago.TransactionID) {
-			instance.LogTrace("SpendDAG.SpenderAccepted", "conflictID", conflictID)
-		}).Unhook,
-
-		instance.Ledger.OnTransactionAttached(func(transactionMetadata mempool.TransactionMetadata) {
-			instance.LogTrace("Ledger.TransactionAttached", "tx", transactionMetadata.ID())
-
-			transactionMetadata.OnSolid(func() {
-				instance.LogTrace("MemPool.TransactionSolid", "tx", transactionMetadata.ID())
-			})
-
-			transactionMetadata.OnExecuted(func() {
-				instance.LogTrace("MemPool.TransactionExecuted", "tx", transactionMetadata.ID())
-			})
-
-			transactionMetadata.OnBooked(func() {
-				instance.LogTrace("MemPool.TransactionBooked", "tx", transactionMetadata.ID())
-			})
-
-			transactionMetadata.OnAccepted(func() {
-				instance.LogTrace("MemPool.TransactionAccepted", "tx", transactionMetadata.ID())
-			})
-
-			transactionMetadata.OnRejected(func() {
-				instance.LogTrace("MemPool.TransactionRejected", "tx", transactionMetadata.ID())
-			})
-
-			transactionMetadata.OnInvalid(func(err error) {
-				instance.LogTrace("MemPool.TransactionInvalid", "tx", transactionMetadata.ID(), "err", err)
-			})
-
-			transactionMetadata.OnOrphanedSlotUpdated(func(slot iotago.SlotIndex) {
-				instance.LogTrace("MemPool.TransactionOrphanedSlotUpdated", "tx", transactionMetadata.ID(), "slot", slot)
-			})
-
-			transactionMetadata.OnCommittedSlotUpdated(func(slot iotago.SlotIndex) {
-				instance.LogTrace("MemPool.TransactionCommittedSlotUpdated", "tx", transactionMetadata.ID(), "slot", slot)
-			})
-
-			transactionMetadata.OnEvicted(func() {
-				instance.LogTrace("MemPool.TransactionEvicted", "tx", transactionMetadata.ID())
-			})
-		}).Unhook,
-
-		instance.Ledger.MemPool().OnSignedTransactionAttached(
-			func(signedTransactionMetadata mempool.SignedTransactionMetadata) {
-				signedTransactionMetadata.OnSignaturesInvalid(func(err error) {
-					instance.LogTrace("MemPool.SignedTransactionSignaturesInvalid", "signedTx", signedTransactionMetadata.ID(), "tx", signedTransactionMetadata.TransactionMetadata().ID(), "err", err)
-				})
-			},
-		).Unhook,
-	)
 }
 
 // WithInitializedEngines is a reactive selector that executes the given callback for each managed chain that

--- a/pkg/protocol/engine/engine.go
+++ b/pkg/protocol/engine/engine.go
@@ -671,7 +671,7 @@ func (e *Engine) initModule() {
 func (e *Engine) attachEngineLogs() (teardown func()) {
 	return lo.Batch(
 		e.ConstructedEvent().LogUpdates(e, log.LevelTrace, "Constructed"),
-		e.InitializedEvent().LogUpdates(e, log.LevelTrace, "Initialized"),
+		e.InitializedEvent().LogUpdates(e, log.LevelInfo, "Initialized"),
 		e.ShutdownEvent().LogUpdates(e, log.LevelInfo, "Shutdown"),
 		e.StoppedEvent().LogUpdates(e, log.LevelInfo, "Stopped"),
 

--- a/pkg/protocol/engine/engine.go
+++ b/pkg/protocol/engine/engine.go
@@ -690,10 +690,6 @@ func (e *Engine) attachEngineLogs() (teardown func()) {
 					logMessage("BlockDAG.BlockSolid", "block", block.ID())
 				}).Unhook,
 
-				e.Events.BlockDAG.BlockInvalid.Hook(func(block *blocks.Block, err error) {
-					logMessage("BlockDAG.BlockInvalid", "block", block.ID(), "err", err)
-				}).Unhook,
-
 				e.Events.BlockDAG.BlockMissing.Hook(func(block *blocks.Block) {
 					logMessage("BlockDAG.BlockMissing", "block", block.ID())
 				}).Unhook,
@@ -710,14 +706,6 @@ func (e *Engine) attachEngineLogs() (teardown func()) {
 					logMessage("Booker.BlockBooked", "block", block.ID())
 				}).Unhook,
 
-				e.Events.Booker.BlockInvalid.Hook(func(block *blocks.Block, err error) {
-					logMessage("Booker.BlockInvalid", "block", block.ID(), "err", err)
-				}).Unhook,
-
-				e.Events.Booker.TransactionInvalid.Hook(func(metadata mempool.TransactionMetadata, err error) {
-					logMessage("Booker.TransactionInvalid", "tx", metadata.ID(), "err", err)
-				}).Unhook,
-
 				e.Events.Scheduler.BlockScheduled.Hook(func(block *blocks.Block) {
 					logMessage("Scheduler.BlockScheduled", "block", block.ID())
 				}).Unhook,
@@ -728,10 +716,6 @@ func (e *Engine) attachEngineLogs() (teardown func()) {
 
 				e.Events.Scheduler.BlockSkipped.Hook(func(block *blocks.Block) {
 					logMessage("Scheduler.BlockSkipped", "block", block.ID())
-				}).Unhook,
-
-				e.Events.Scheduler.BlockDropped.Hook(func(block *blocks.Block, err error) {
-					logMessage("Scheduler.BlockDropped", "block", block.ID(), "err", err)
 				}).Unhook,
 
 				e.Events.Clock.AcceptedTimeUpdated.Hook(func(newTime time.Time) {
@@ -746,16 +730,8 @@ func (e *Engine) attachEngineLogs() (teardown func()) {
 					logMessage("PreSolidFilter.BlockPreAllowed", "block", block.ID())
 				}).Unhook,
 
-				e.Events.PreSolidFilter.BlockPreFiltered.Hook(func(event *presolidfilter.BlockPreFilteredEvent) {
-					logMessage("PreSolidFilter.BlockPreFiltered", "block", event.Block.ID(), "err", event.Reason)
-				}).Unhook,
-
 				e.Events.PostSolidFilter.BlockAllowed.Hook(func(block *blocks.Block) {
 					logMessage("PostSolidFilter.BlockAllowed", "block", block.ID())
-				}).Unhook,
-
-				e.Events.PostSolidFilter.BlockFiltered.Hook(func(event *postsolidfilter.BlockFilteredEvent) {
-					logMessage("PostSolidFilter.BlockFiltered", "block", event.Block.ID(), "err", event.Reason)
 				}).Unhook,
 
 				e.Events.BlockRequester.Tick.Hook(func(blockID iotago.BlockID) {
@@ -778,16 +754,12 @@ func (e *Engine) attachEngineLogs() (teardown func()) {
 					logMessage("BlockGadget.BlockPreAccepted", "block", block.ID(), "slotCommitmentID", block.ProtocolBlock().Header.SlotCommitmentID)
 				}).Unhook,
 
-				e.Events.BlockGadget.BlockAccepted.Hook(func(block *blocks.Block) {
-					logMessage("BlockGadget.BlockAccepted", "block", block.ID(), "slotCommitmentID", block.ProtocolBlock().Header.SlotCommitmentID)
-				}).Unhook,
-
 				e.Events.BlockGadget.BlockPreConfirmed.Hook(func(block *blocks.Block) {
 					logMessage("BlockGadget.BlockPreConfirmed", "block", block.ID(), "slotCommitmentID", block.ProtocolBlock().Header.SlotCommitmentID)
 				}).Unhook,
 
-				e.Events.BlockGadget.BlockConfirmed.Hook(func(block *blocks.Block) {
-					logMessage("BlockGadget.BlockConfirmed", "block", block.ID(), "slotCommitmentID", block.ProtocolBlock().Header.SlotCommitmentID)
+				e.Events.Notarization.LatestCommitmentUpdated.Hook(func(commitment *model.Commitment) {
+					logMessage("NotarizationManager.LatestCommitmentUpdated", "commitment", commitment.ID())
 				}).Unhook,
 
 				e.Events.SpendDAG.SpenderCreated.Hook(func(conflictID iotago.TransactionID) {
@@ -860,6 +832,38 @@ func (e *Engine) attachEngineLogs() (teardown func()) {
 			logMessage := e.LogDebug
 
 			return lo.Batch(
+				e.Events.BlockDAG.BlockInvalid.Hook(func(block *blocks.Block, err error) {
+					logMessage("BlockDAG.BlockInvalid", "block", block.ID(), "err", err)
+				}).Unhook,
+
+				e.Events.PreSolidFilter.BlockPreFiltered.Hook(func(event *presolidfilter.BlockPreFilteredEvent) {
+					logMessage("PreSolidFilter.BlockPreFiltered", "block", event.Block.ID(), "err", event.Reason)
+				}).Unhook,
+
+				e.Events.PostSolidFilter.BlockFiltered.Hook(func(event *postsolidfilter.BlockFilteredEvent) {
+					logMessage("PostSolidFilter.BlockFiltered", "block", event.Block.ID(), "err", event.Reason)
+				}).Unhook,
+
+				e.Events.Booker.BlockInvalid.Hook(func(block *blocks.Block, err error) {
+					logMessage("Booker.BlockInvalid", "block", block.ID(), "err", err)
+				}).Unhook,
+
+				e.Events.Booker.TransactionInvalid.Hook(func(metadata mempool.TransactionMetadata, err error) {
+					logMessage("Booker.TransactionInvalid", "tx", metadata.ID(), "err", err)
+				}).Unhook,
+
+				e.Events.Scheduler.BlockDropped.Hook(func(block *blocks.Block, err error) {
+					logMessage("Scheduler.BlockDropped", "block", block.ID(), "err", err)
+				}).Unhook,
+
+				e.Events.BlockGadget.BlockAccepted.Hook(func(block *blocks.Block) {
+					logMessage("BlockGadget.BlockAccepted", "block", block.ID(), "slotCommitmentID", block.ProtocolBlock().Header.SlotCommitmentID)
+				}).Unhook,
+
+				e.Events.BlockGadget.BlockConfirmed.Hook(func(block *blocks.Block) {
+					logMessage("BlockGadget.BlockConfirmed", "block", block.ID(), "slotCommitmentID", block.ProtocolBlock().Header.SlotCommitmentID)
+				}).Unhook,
+
 				e.Events.SlotGadget.SlotFinalized.Hook(func(slot iotago.SlotIndex) {
 					logMessage("SlotGadget.SlotFinalized", "slot", slot)
 				}).Unhook,
@@ -868,8 +872,12 @@ func (e *Engine) attachEngineLogs() (teardown func()) {
 					logMessage("NotarizationManager.SlotCommitted", "commitment", details.Commitment.ID(), "acceptedBlocks count", details.AcceptedBlocks.Size(), "accepted transactions", len(details.Mutations))
 				}).Unhook,
 
-				e.Events.Notarization.LatestCommitmentUpdated.Hook(func(commitment *model.Commitment) {
-					logMessage("NotarizationManager.LatestCommitmentUpdated", "commitment", commitment.ID())
+				e.Events.SeatManager.OnlineCommitteeSeatAdded.Hook(func(seat account.SeatIndex, accountID iotago.AccountID) {
+					logMessage("SybilProtection.OnlineCommitteeSeatAdded", "seat", seat, "accountID", accountID)
+				}).Unhook,
+
+				e.Events.SeatManager.OnlineCommitteeSeatRemoved.Hook(func(seat account.SeatIndex) {
+					logMessage("SybilProtection.OnlineCommitteeSeatRemoved", "seat", seat)
 				}).Unhook,
 			)
 		}),
@@ -878,16 +886,8 @@ func (e *Engine) attachEngineLogs() (teardown func()) {
 			logMessage := e.LogInfo
 
 			return lo.Batch(
-				e.Events.SeatManager.OnlineCommitteeSeatRemoved.Hook(func(seat account.SeatIndex) {
-					logMessage("SybilProtection.OnlineCommitteeSeatRemoved", "seat", seat)
-				}).Unhook,
-
 				e.Events.SybilProtection.CommitteeSelected.Hook(func(committee *account.SeatedAccounts, epoch iotago.EpochIndex) {
 					logMessage("SybilProtection.CommitteeSelected", "epoch", epoch, "committee", committee.IDs())
-				}).Unhook,
-
-				e.Events.SeatManager.OnlineCommitteeSeatAdded.Hook(func(seat account.SeatIndex, accountID iotago.AccountID) {
-					logMessage("SybilProtection.OnlineCommitteeSeatAdded", "seat", seat, "accountID", accountID)
 				}).Unhook,
 			)
 		}),

--- a/pkg/protocol/engine/engine.go
+++ b/pkg/protocol/engine/engine.go
@@ -21,6 +21,7 @@ import (
 	"github.com/iotaledger/hive.go/runtime/options"
 	"github.com/iotaledger/hive.go/runtime/syncutils"
 	"github.com/iotaledger/hive.go/runtime/workerpool"
+	"github.com/iotaledger/iota-core/pkg/core/account"
 	"github.com/iotaledger/iota-core/pkg/model"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/attestation"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/blockdag"
@@ -34,6 +35,7 @@ import (
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/filter/postsolidfilter"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/filter/presolidfilter"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/ledger"
+	"github.com/iotaledger/iota-core/pkg/protocol/engine/mempool"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/notarization"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/syncmanager"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/tipmanager"
@@ -138,12 +140,13 @@ func New(
 			RootCommitment:   reactive.NewVariable[*model.Commitment](),
 			LatestCommitment: reactive.NewVariable[*model.Commitment](),
 			Workers:          workers,
+			Module:           module.New(logger.NewChildLogger("Engine", true)),
 
 			optsSnapshotPath:    "snapshot.bin",
 			optsSnapshotDepth:   5,
 			optsCheckCommitment: true,
 		}, opts, func(e *Engine) {
-			e.Module = e.initReactiveModule(logger)
+			e.initModule()
 
 			e.errorHandler = func(err error) {
 				e.LogError("engine error", "err", err)
@@ -648,15 +651,10 @@ func (e *Engine) initLatestCommitment() {
 	})
 }
 
-func (e *Engine) initReactiveModule(parentLogger log.Logger) (reactiveModule module.Module) {
-	reactiveModule = module.New(parentLogger.NewChildLogger("Engine", true))
+func (e *Engine) initModule() {
+	detachEngineLogs := e.attachEngineLogs()
 
-	e.RootCommitment.LogUpdates(reactiveModule, log.LevelTrace, "RootCommitment")
-	e.LatestCommitment.LogUpdates(reactiveModule, log.LevelTrace, "LatestCommitment")
-
-	reactiveModule.ShutdownEvent().OnTrigger(func() {
-		reactiveModule.LogDebug("shutting down")
-
+	e.ShutdownEvent().OnTrigger(func() {
 		e.BlockRequester.Shutdown()
 
 		e.shutdownSubModules()
@@ -666,10 +664,234 @@ func (e *Engine) initReactiveModule(parentLogger log.Logger) (reactiveModule mod
 
 		e.StoppedEvent().Trigger()
 
-		reactiveModule.LogDebug("stopped")
+		detachEngineLogs()
 	})
+}
 
-	return reactiveModule
+func (e *Engine) attachEngineLogs() (teardown func()) {
+	return lo.Batch(
+		e.ConstructedEvent().LogUpdates(e, log.LevelTrace, "Constructed"),
+		e.InitializedEvent().LogUpdates(e, log.LevelTrace, "Initialized"),
+		e.ShutdownEvent().LogUpdates(e, log.LevelInfo, "Shutdown"),
+		e.StoppedEvent().LogUpdates(e, log.LevelInfo, "Stopped"),
+
+		e.RootCommitment.LogUpdates(e, log.LevelTrace, "RootCommitment"),
+		e.LatestCommitment.LogUpdates(e, log.LevelTrace, "LatestCommitment"),
+
+		e.OnLogLevelActive(log.LevelTrace, func() (shutdown func()) {
+			logMessage := e.LogTrace
+
+			return lo.BatchReverse(
+				e.Events.BlockDAG.BlockAppended.Hook(func(block *blocks.Block) {
+					logMessage("BlockDAG.BlockAppended", "block", block.ID())
+				}).Unhook,
+
+				e.Events.BlockDAG.BlockSolid.Hook(func(block *blocks.Block) {
+					logMessage("BlockDAG.BlockSolid", "block", block.ID())
+				}).Unhook,
+
+				e.Events.BlockDAG.BlockInvalid.Hook(func(block *blocks.Block, err error) {
+					logMessage("BlockDAG.BlockInvalid", "block", block.ID(), "err", err)
+				}).Unhook,
+
+				e.Events.BlockDAG.BlockMissing.Hook(func(block *blocks.Block) {
+					logMessage("BlockDAG.BlockMissing", "block", block.ID())
+				}).Unhook,
+
+				e.Events.BlockDAG.MissingBlockAppended.Hook(func(block *blocks.Block) {
+					logMessage("BlockDAG.MissingBlockAppended", "block", block.ID())
+				}).Unhook,
+
+				e.Events.SeatManager.BlockProcessed.Hook(func(block *blocks.Block) {
+					logMessage("SeatManager.BlockProcessed", "block", block.ID())
+				}).Unhook,
+
+				e.Events.Booker.BlockBooked.Hook(func(block *blocks.Block) {
+					logMessage("Booker.BlockBooked", "block", block.ID())
+				}).Unhook,
+
+				e.Events.Booker.BlockInvalid.Hook(func(block *blocks.Block, err error) {
+					logMessage("Booker.BlockInvalid", "block", block.ID(), "err", err)
+				}).Unhook,
+
+				e.Events.Booker.TransactionInvalid.Hook(func(metadata mempool.TransactionMetadata, err error) {
+					logMessage("Booker.TransactionInvalid", "tx", metadata.ID(), "err", err)
+				}).Unhook,
+
+				e.Events.Scheduler.BlockScheduled.Hook(func(block *blocks.Block) {
+					logMessage("Scheduler.BlockScheduled", "block", block.ID())
+				}).Unhook,
+
+				e.Events.Scheduler.BlockEnqueued.Hook(func(block *blocks.Block) {
+					logMessage("Scheduler.BlockEnqueued", "block", block.ID())
+				}).Unhook,
+
+				e.Events.Scheduler.BlockSkipped.Hook(func(block *blocks.Block) {
+					logMessage("Scheduler.BlockSkipped", "block", block.ID())
+				}).Unhook,
+
+				e.Events.Scheduler.BlockDropped.Hook(func(block *blocks.Block, err error) {
+					logMessage("Scheduler.BlockDropped", "block", block.ID(), "err", err)
+				}).Unhook,
+
+				e.Events.Clock.AcceptedTimeUpdated.Hook(func(newTime time.Time) {
+					logMessage("Clock.AcceptedTimeUpdated", "time", newTime, "slot", e.LatestAPI().TimeProvider().SlotFromTime(newTime))
+				}).Unhook,
+
+				e.Events.Clock.ConfirmedTimeUpdated.Hook(func(newTime time.Time) {
+					logMessage("Clock.ConfirmedTimeUpdated", "time", newTime, "slot", e.LatestAPI().TimeProvider().SlotFromTime(newTime))
+				}).Unhook,
+
+				e.Events.PreSolidFilter.BlockPreAllowed.Hook(func(block *model.Block) {
+					logMessage("PreSolidFilter.BlockPreAllowed", "block", block.ID())
+				}).Unhook,
+
+				e.Events.PreSolidFilter.BlockPreFiltered.Hook(func(event *presolidfilter.BlockPreFilteredEvent) {
+					logMessage("PreSolidFilter.BlockPreFiltered", "block", event.Block.ID(), "err", event.Reason)
+				}).Unhook,
+
+				e.Events.PostSolidFilter.BlockAllowed.Hook(func(block *blocks.Block) {
+					logMessage("PostSolidFilter.BlockAllowed", "block", block.ID())
+				}).Unhook,
+
+				e.Events.PostSolidFilter.BlockFiltered.Hook(func(event *postsolidfilter.BlockFilteredEvent) {
+					logMessage("PostSolidFilter.BlockFiltered", "block", event.Block.ID(), "err", event.Reason)
+				}).Unhook,
+
+				e.Events.BlockRequester.Tick.Hook(func(blockID iotago.BlockID) {
+					logMessage("BlockRequester.Tick", "block", blockID)
+				}).Unhook,
+
+				e.Events.BlockProcessed.Hook(func(blockID iotago.BlockID) {
+					logMessage("BlockProcessed", "block", blockID)
+				}).Unhook,
+
+				e.Events.BlockRetainer.BlockRetained.Hook(func(block *blocks.Block) {
+					logMessage("Retainer.BlockRetained", "block", block.ID())
+				}).Unhook,
+
+				e.Events.TransactionRetainer.TransactionRetained.Hook(func(txID iotago.TransactionID) {
+					logMessage("Retainer.TransactionRetained", "transaction", txID)
+				}).Unhook,
+
+				e.Events.BlockGadget.BlockPreAccepted.Hook(func(block *blocks.Block) {
+					logMessage("BlockGadget.BlockPreAccepted", "block", block.ID(), "slotCommitmentID", block.ProtocolBlock().Header.SlotCommitmentID)
+				}).Unhook,
+
+				e.Events.BlockGadget.BlockAccepted.Hook(func(block *blocks.Block) {
+					logMessage("BlockGadget.BlockAccepted", "block", block.ID(), "slotCommitmentID", block.ProtocolBlock().Header.SlotCommitmentID)
+				}).Unhook,
+
+				e.Events.BlockGadget.BlockPreConfirmed.Hook(func(block *blocks.Block) {
+					logMessage("BlockGadget.BlockPreConfirmed", "block", block.ID(), "slotCommitmentID", block.ProtocolBlock().Header.SlotCommitmentID)
+				}).Unhook,
+
+				e.Events.BlockGadget.BlockConfirmed.Hook(func(block *blocks.Block) {
+					logMessage("BlockGadget.BlockConfirmed", "block", block.ID(), "slotCommitmentID", block.ProtocolBlock().Header.SlotCommitmentID)
+				}).Unhook,
+
+				e.Events.SpendDAG.SpenderCreated.Hook(func(conflictID iotago.TransactionID) {
+					logMessage("SpendDAG.SpenderCreated", "conflictID", conflictID)
+				}).Unhook,
+
+				e.Events.SpendDAG.SpenderEvicted.Hook(func(conflictID iotago.TransactionID) {
+					logMessage("SpendDAG.SpenderEvicted", "conflictID", conflictID)
+				}).Unhook,
+
+				e.Events.SpendDAG.SpenderRejected.Hook(func(conflictID iotago.TransactionID) {
+					logMessage("SpendDAG.SpenderRejected", "conflictID", conflictID)
+				}).Unhook,
+
+				e.Events.SpendDAG.SpenderAccepted.Hook(func(conflictID iotago.TransactionID) {
+					logMessage("SpendDAG.SpenderAccepted", "conflictID", conflictID)
+				}).Unhook,
+
+				e.Ledger.OnTransactionAttached(func(transactionMetadata mempool.TransactionMetadata) {
+					logMessage("Ledger.TransactionAttached", "tx", transactionMetadata.ID())
+
+					transactionMetadata.OnSolid(func() {
+						logMessage("MemPool.TransactionSolid", "tx", transactionMetadata.ID())
+					})
+
+					transactionMetadata.OnExecuted(func() {
+						logMessage("MemPool.TransactionExecuted", "tx", transactionMetadata.ID())
+					})
+
+					transactionMetadata.OnBooked(func() {
+						logMessage("MemPool.TransactionBooked", "tx", transactionMetadata.ID())
+					})
+
+					transactionMetadata.OnAccepted(func() {
+						logMessage("MemPool.TransactionAccepted", "tx", transactionMetadata.ID())
+					})
+
+					transactionMetadata.OnRejected(func() {
+						logMessage("MemPool.TransactionRejected", "tx", transactionMetadata.ID())
+					})
+
+					transactionMetadata.OnInvalid(func(err error) {
+						logMessage("MemPool.TransactionInvalid", "tx", transactionMetadata.ID(), "err", err)
+					})
+
+					transactionMetadata.OnOrphanedSlotUpdated(func(slot iotago.SlotIndex) {
+						logMessage("MemPool.TransactionOrphanedSlotUpdated", "tx", transactionMetadata.ID(), "slot", slot)
+					})
+
+					transactionMetadata.OnCommittedSlotUpdated(func(slot iotago.SlotIndex) {
+						logMessage("MemPool.TransactionCommittedSlotUpdated", "tx", transactionMetadata.ID(), "slot", slot)
+					})
+
+					transactionMetadata.OnEvicted(func() {
+						logMessage("MemPool.TransactionEvicted", "tx", transactionMetadata.ID())
+					})
+				}).Unhook,
+
+				e.Ledger.MemPool().OnSignedTransactionAttached(
+					func(signedTransactionMetadata mempool.SignedTransactionMetadata) {
+						signedTransactionMetadata.OnSignaturesInvalid(func(err error) {
+							logMessage("MemPool.SignedTransactionSignaturesInvalid", "signedTx", signedTransactionMetadata.ID(), "tx", signedTransactionMetadata.TransactionMetadata().ID(), "err", err)
+						})
+					},
+				).Unhook,
+			)
+		}),
+
+		e.OnLogLevelActive(log.LevelDebug, func() (shutdown func()) {
+			logMessage := e.LogDebug
+
+			return lo.Batch(
+				e.Events.SlotGadget.SlotFinalized.Hook(func(slot iotago.SlotIndex) {
+					logMessage("SlotGadget.SlotFinalized", "slot", slot)
+				}).Unhook,
+
+				e.Events.Notarization.SlotCommitted.Hook(func(details *notarization.SlotCommittedDetails) {
+					logMessage("NotarizationManager.SlotCommitted", "commitment", details.Commitment.ID(), "acceptedBlocks count", details.AcceptedBlocks.Size(), "accepted transactions", len(details.Mutations))
+				}).Unhook,
+
+				e.Events.Notarization.LatestCommitmentUpdated.Hook(func(commitment *model.Commitment) {
+					logMessage("NotarizationManager.LatestCommitmentUpdated", "commitment", commitment.ID())
+				}).Unhook,
+			)
+		}),
+
+		e.OnLogLevelActive(log.LevelInfo, func() (shutdown func()) {
+			logMessage := e.LogInfo
+
+			return lo.Batch(
+				e.Events.SeatManager.OnlineCommitteeSeatRemoved.Hook(func(seat account.SeatIndex) {
+					logMessage("SybilProtection.OnlineCommitteeSeatRemoved", "seat", seat)
+				}).Unhook,
+
+				e.Events.SybilProtection.CommitteeSelected.Hook(func(committee *account.SeatedAccounts, epoch iotago.EpochIndex) {
+					logMessage("SybilProtection.CommitteeSelected", "epoch", epoch, "committee", committee.IDs())
+				}).Unhook,
+
+				e.Events.SeatManager.OnlineCommitteeSeatAdded.Hook(func(seat account.SeatIndex, accountID iotago.AccountID) {
+					logMessage("SybilProtection.OnlineCommitteeSeatAdded", "seat", seat, "accountID", accountID)
+				}).Unhook,
+			)
+		}),
+	)
 }
 
 func (e *Engine) shutdownSubModules() {

--- a/pkg/protocol/engine/engine.go
+++ b/pkg/protocol/engine/engine.go
@@ -690,14 +690,6 @@ func (e *Engine) attachEngineLogs() (teardown func()) {
 					logMessage("BlockDAG.BlockSolid", "block", block.ID())
 				}).Unhook,
 
-				e.Events.BlockDAG.BlockMissing.Hook(func(block *blocks.Block) {
-					logMessage("BlockDAG.BlockMissing", "block", block.ID())
-				}).Unhook,
-
-				e.Events.BlockDAG.MissingBlockAppended.Hook(func(block *blocks.Block) {
-					logMessage("BlockDAG.MissingBlockAppended", "block", block.ID())
-				}).Unhook,
-
 				e.Events.SeatManager.BlockProcessed.Hook(func(block *blocks.Block) {
 					logMessage("SeatManager.BlockProcessed", "block", block.ID())
 				}).Unhook,
@@ -832,6 +824,14 @@ func (e *Engine) attachEngineLogs() (teardown func()) {
 			logMessage := e.LogDebug
 
 			return lo.Batch(
+				e.Events.BlockDAG.BlockMissing.Hook(func(block *blocks.Block) {
+					logMessage("BlockDAG.BlockMissing", "block", block.ID())
+				}).Unhook,
+
+				e.Events.BlockDAG.MissingBlockAppended.Hook(func(block *blocks.Block) {
+					logMessage("BlockDAG.MissingBlockAppended", "block", block.ID())
+				}).Unhook,
+
 				e.Events.BlockDAG.BlockInvalid.Hook(func(block *blocks.Block, err error) {
 					logMessage("BlockDAG.BlockInvalid", "block", block.ID(), "err", err)
 				}).Unhook,

--- a/pkg/protocol/engine/notarization/slotnotarization/manager.go
+++ b/pkg/protocol/engine/notarization/slotnotarization/manager.go
@@ -141,7 +141,7 @@ func (m *Manager) ForceCommit(slot iotago.SlotIndex) (*model.Commitment, error) 
 		return nil, ierrors.Wrapf(err, "failed to create commitment for slot %d", slot)
 	}
 
-	m.LogInfo("forced commitment", "commitmentID", commitment.ID())
+	m.LogTrace("forced commitment", "commitmentID", commitment.ID())
 
 	return commitment, nil
 }

--- a/pkg/protocol/engine/syncmanager/trivialsyncmanager/syncmanager.go
+++ b/pkg/protocol/engine/syncmanager/trivialsyncmanager/syncmanager.go
@@ -270,7 +270,7 @@ func (s *SyncManager) updateSyncStatus() (changed bool) {
 	s.isSyncedLock.Lock()
 	defer s.isSyncedLock.Unlock()
 
-	isSynced := s.isBootstrapped && time.Since(s.engine.Clock.Accepted().RelativeTime()) < s.optsSyncThreshold
+	isSynced := s.IsBootstrapped() && time.Since(s.engine.Clock.Accepted().RelativeTime()) < s.optsSyncThreshold
 	if s.isSynced != isSynced {
 		s.isSynced = isSynced
 

--- a/pkg/protocol/sybilprotection/sybilprotectionv1/sybilprotection.go
+++ b/pkg/protocol/sybilprotection/sybilprotectionv1/sybilprotection.go
@@ -235,7 +235,7 @@ func (o *SybilProtection) committeeRoot(targetCommitteeEpoch iotago.EpochIndex) 
 
 	committeeIDs := committee.IDs()
 
-	o.LogDebug("generating committee root", "committeeIDs", committeeIDs, "epoch", targetCommitteeEpoch)
+	o.LogTrace("generating committee root", "committeeIDs", committeeIDs, "epoch", targetCommitteeEpoch)
 
 	for _, accountID := range committeeIDs {
 		if err = committeeTree.Add(accountID); err != nil {

--- a/pkg/tests/loss_of_acceptance_test.go
+++ b/pkg/tests/loss_of_acceptance_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotaledger/hive.go/lo"
+	"github.com/iotaledger/hive.go/log"
 	"github.com/iotaledger/iota-core/pkg/core/account"
 	"github.com/iotaledger/iota-core/pkg/protocol"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/blocks"
@@ -133,6 +134,9 @@ func TestEngineSwitchingUponStartupWithLossOfAcceptance(t *testing.T) {
 
 	ts.Run(true, nil)
 
+	node0.Protocol.SetLogLevel(log.LevelDebug)
+	node1.Protocol.SetLogLevel(log.LevelDebug)
+
 	// Create snapshot to use later.
 	snapshotPath := ts.Directory.Path(fmt.Sprintf("%d_snapshot", time.Now().Unix()))
 	require.NoError(t, node0.Protocol.Engines.Main.Get().WriteSnapshot(snapshotPath))
@@ -206,6 +210,7 @@ func TestEngineSwitchingUponStartupWithLossOfAcceptance(t *testing.T) {
 			protocol.WithSnapshotPath(snapshotPath),
 			protocol.WithBaseDirectory(ts.Directory.PathWithCreate(node3.Name)),
 		)
+		node3.Protocol.SetLogLevel(log.LevelDebug)
 
 		ts.Wait()
 	}

--- a/pkg/tests/loss_of_acceptance_test.go
+++ b/pkg/tests/loss_of_acceptance_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotaledger/hive.go/lo"
-	"github.com/iotaledger/hive.go/log"
 	"github.com/iotaledger/iota-core/pkg/core/account"
 	"github.com/iotaledger/iota-core/pkg/protocol"
 	"github.com/iotaledger/iota-core/pkg/protocol/engine/blocks"
@@ -134,9 +133,6 @@ func TestEngineSwitchingUponStartupWithLossOfAcceptance(t *testing.T) {
 
 	ts.Run(true, nil)
 
-	node0.Protocol.SetLogLevel(log.LevelDebug)
-	node1.Protocol.SetLogLevel(log.LevelDebug)
-
 	// Create snapshot to use later.
 	snapshotPath := ts.Directory.Path(fmt.Sprintf("%d_snapshot", time.Now().Unix()))
 	require.NoError(t, node0.Protocol.Engines.Main.Get().WriteSnapshot(snapshotPath))
@@ -210,7 +206,6 @@ func TestEngineSwitchingUponStartupWithLossOfAcceptance(t *testing.T) {
 			protocol.WithSnapshotPath(snapshotPath),
 			protocol.WithBaseDirectory(ts.Directory.PathWithCreate(node3.Name)),
 		)
-		node3.Protocol.SetLogLevel(log.LevelDebug)
 
 		ts.Wait()
 	}


### PR DESCRIPTION
This PR builds on top of https://github.com/iotaledger/iota-core/pull/940 and changes the logging to have a more fine grained separation between INFO, DEBUG and TRACE.

It also moves the engine related logging logic to the engine package.